### PR TITLE
Adding logging sink for debugging stats

### DIFF
--- a/logging_sink.go
+++ b/logging_sink.go
@@ -1,0 +1,22 @@
+package stats
+
+import logger "github.com/Sirupsen/logrus"
+
+type loggingSink struct {
+}
+
+func NewLoggingSink() Sink {
+	return &loggingSink{}
+}
+
+func (s *loggingSink) FlushCounter(name string, value uint64) {
+	logger.Infof("[gostats] flushing counter %s: %d", name, value)
+}
+
+func (s *loggingSink) FlushGauge(name string, value uint64) {
+	logger.Infof("[gostats] flushing gauge %s: %d", name, value)
+}
+
+func (s *loggingSink) FlushTimer(name string, value float64) {
+	logger.Infof("[gostats] flushing time %s: %f", name, value)
+}

--- a/stats.go
+++ b/stats.go
@@ -185,7 +185,8 @@ func NewDefaultStore() Store {
 	settings := GetSettings()
 	if !settings.UseStatsd {
 		logger.Warn("statsd is not in use")
-		newStore = NewStore(NewNullSink(), true)
+		newStore = NewStore(NewLoggingSink(), false)
+		go newStore.Start(time.NewTicker(10 * time.Second))
 	} else {
 		newStore = NewStore(NewTcpStatsdSink(), true)
 		go newStore.Start(time.NewTicker(time.Duration(settings.FlushIntervalS) * time.Second))


### PR DESCRIPTION
This branch adds a logging `Sink` and configures it when the `USE_STATSD` environment variable is set to `false`. We use this internally for debugging stats in development.