### PR TITLE
Fix race in Flush and AddStatGenerator

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -299,12 +299,12 @@ type statStore struct {
 }
 
 func (s *statStore) Flush() {
+	s.Lock()
+	defer s.Unlock()
+
 	for _, g := range s.statGenerators {
 		g.GenerateStats()
 	}
-
-	s.Lock()
-	defer s.Unlock()
 
 	for name, cv := range s.counters {
 		value := cv.latch()
@@ -328,6 +328,9 @@ func (s *statStore) Start(ticker *time.Ticker) {
 }
 
 func (s *statStore) AddStatGenerator(statGenerator StatGenerator) {
+	s.Lock()
+	defer s.Unlock()
+
 	s.statGenerators = append(s.statGenerators, statGenerator)
 }
 

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,0 +1,31 @@
+package stats
+
+import (
+	"sync"
+	"testing"
+)
+
+// Ensure flushing and adding generators does not race
+func TestStats(t *testing.T) {
+	sink := &testStatSink{}
+	store := NewStore(sink, false)
+
+	scope := store.Scope("runtime")
+	g := NewRuntimeStats(scope)
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		store.AddStatGenerator(g)
+		store.Flush()
+		wg.Done()
+	}()
+
+	go func() {
+		store.AddStatGenerator(g)
+		store.Flush()
+		wg.Done()
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
Found this while testing in another service.

```
WARNING: DATA RACE
Read at 0x00c42009aad0 by goroutine 10:
  github.com/lyft/srv/vendor/github.com/lyft/gostats.(*statStore).Flush()
      /Users/christopherburnett/Go/src/github.com/lyft/srv/vendor/github.com/lyft/gostats/stats.go:302 +0x57
  github.com/lyft/srv/vendor/github.com/lyft/gostats.(*statStore).run()
      /Users/christopherburnett/Go/src/github.com/lyft/srv/vendor/github.com/lyft/gostats/stats.go:336 +0xb6
  github.com/lyft/srv/vendor/github.com/lyft/gostats.(*statStore).Start()
      /Users/christopherburnett/Go/src/github.com/lyft/srv/vendor/github.com/lyft/gostats/stats.go:327 +0x42

Previous write at 0x00c42009aad0 by goroutine 8:
  github.com/lyft/srv/vendor/github.com/lyft/gostats.(*statStore).AddStatGenerator()
      /Users/christopherburnett/Go/src/github.com/lyft/srv/vendor/github.com/lyft/gostats/stats.go:331 +0xd9
  github.com/lyft/srv/config.NewDefault()
      /Users/christopherburnett/Go/src/github.com/lyft/srv/config/config.go:103 +0x2fe
  github.com/lyft/srv/config/server.NewDefault()
      /Users/christopherburnett/Go/src/github.com/lyft/srv/config/server/server.go:22 +0x46
  github.com/lyft/srv/server.TestServer()
      /Users/christopherburnett/Go/src/github.com/lyft/srv/server/server_integration_test.go:37 +0x5b
  testing.tRunner()
      /usr/local/Cellar/go/1.7.1/libexec/src/testing/testing.go:610 +0xc9
```