### PR TITLE
Prevent panic on duplicate export of exp vars

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -358,7 +358,7 @@ func (registry *statStore) NewCounter(name string) Counter {
 	} else {
 		counterv = &counter{}
 		registry.counters[name] = counterv
-		if registry.export {
+		if registry.export && expvar.Get(name) == nil {
 			expvar.Publish(name, counterv)
 		}
 		return counterv
@@ -392,7 +392,7 @@ func (registry *statStore) NewGauge(name string) Gauge {
 	} else {
 		gaugev = &gauge{}
 		registry.gauges[name] = gaugev
-		if registry.export {
+		if registry.export && expvar.Get(name) == nil {
 			expvar.Publish(name, gaugev)
 		}
 		return gaugev

--- a/stats_test.go
+++ b/stats_test.go
@@ -8,7 +8,7 @@ import (
 // Ensure flushing and adding generators does not race
 func TestStats(t *testing.T) {
 	sink := &testStatSink{}
-	store := NewStore(sink, false)
+	store := NewStore(sink, true)
 
 	scope := store.Scope("runtime")
 	g := NewRuntimeStats(scope)


### PR DESCRIPTION
Encountered in tests.

```
panic: Reuse of exported var name: supply.go.alloc

goroutine 25 [running]:
panic(0x644740, 0xc420296290)
	/usr/local/Cellar/go/1.7.5/libexec/src/runtime/panic.go:500 +0x1a1
testing.tRunner.func1(0xc42021e240)
	/usr/local/Cellar/go/1.7.5/libexec/src/testing/testing.go:579 +0x25d
panic(0x644740, 0xc420296290)
	/usr/local/Cellar/go/1.7.5/libexec/src/runtime/panic.go:458 +0x243
log.Panicln(0xc42004d880, 0x2, 0x2)
	/usr/local/Cellar/go/1.7.5/libexec/src/log/log.go:334 +0xc9
expvar.Publish(0xc420296220, 0xf, 0xb0bb40, 0xc420296230)
	/usr/local/Cellar/go/1.7.5/libexec/src/expvar/expvar.go:259 +0x34a
github.com/xxxxxx/vendor/github.com/lyft/gostats.(*statStore).NewGauge(0xc4200747d0, 0xc420296220, 0xf, 0x0, 0x0)
	/Users/christopherburnett/Go/src/github.com/xxxxxx/vendor/github.com/lyft/gostats/stats.go:396 +0x1a7
```