### PR TITLE
Finer-grained mutex locking on Store

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -6,13 +6,13 @@ import "github.com/kelseyhightower/envconfig"
 // variables to setup its settings.
 type Settings struct {
 	// Use statsd as a stats sink.
-	UseStatsd           bool   `envconfig:"USE_STATSD" default:"true"`
+	UseStatsd bool `envconfig:"USE_STATSD" default:"true"`
 	// Address where statsd is running at.
-	StatsdHost          string `envconfig:"STATSD_HOST" default:"localhost"`
+	StatsdHost string `envconfig:"STATSD_HOST" default:"localhost"`
 	// Port where statsd is listening at.
-	StatsdPort          int    `envconfig:"STATSD_PORT" default:"8125"`
-  // Flushing interval.
-	FlushIntervalS      int    `envconfig:"GOSTATS_FLUSH_INTERVAL_SECONDS" default:"5"`
+	StatsdPort int `envconfig:"STATSD_PORT" default:"8125"`
+	// Flushing interval.
+	FlushIntervalS int `envconfig:"GOSTATS_FLUSH_INTERVAL_SECONDS" default:"5"`
 }
 
 // GetSettings returns the Settings gostats will run with.

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,8 +1,11 @@
 package stats
 
 import (
+	"math/rand"
+	"strconv"
 	"sync"
 	"testing"
+	"time"
 )
 
 // Ensure flushing and adding generators does not race
@@ -28,4 +31,22 @@ func TestStats(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+
+var bmID = ""
+var bmVal = uint64(0)
+
+func BenchmarkStore_MutexContention(b *testing.B) {
+	s := NewStore(&nullSink{}, false)
+	t := time.NewTicker(500 * time.Microsecond) // we want flush to contend with accessing metrics
+	defer t.Stop()
+	go s.Start(t)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bmID = strconv.Itoa(rand.Intn(1000))
+		c := s.NewCounter(bmID)
+		c.Inc()
+		bmVal = c.Value()
+	}
 }

--- a/tcp_sink_test.go
+++ b/tcp_sink_test.go
@@ -3,23 +3,31 @@ package stats
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 )
 
 type testStatSink struct {
+	sync.Mutex
 	record string
 }
 
 func (s *testStatSink) FlushCounter(name string, value uint64) {
+	s.Lock()
 	s.record += fmt.Sprintf("%s:%d|c\n", name, value)
+	s.Unlock()
 }
 
 func (s *testStatSink) FlushGauge(name string, value uint64) {
+	s.Lock()
 	s.record += fmt.Sprintf("%s:%d|g\n", name, value)
+	s.Unlock()
 }
 
 func (s *testStatSink) FlushTimer(name string, value float64) {
+	s.Lock()
 	s.record += fmt.Sprintf("%s:%f|ms\n", name, value)
+	s.Unlock()
 }
 
 func TestCreateTimer(t *testing.T) {


### PR DESCRIPTION
The `Store` implementation was using a single `sync.Mutex` to control access to the individual metrics and generators. While this simplifies bookkeeping, it can run into problems with contention
in high-throughput circumstances. This mutex locked the `Flush` method, `StatGenerator` slice, and `Timer`/`Counter`/`Gauge` maps.

One method of improving this is to use a `sync.RWMutex` instead, which permits multiple simultaneous reads, as is often the case a metric is simply being read (with the `New*` methods) or looped over (with `Flush`). Now `Lock` only needs to be called when adding new metrics to the slice/maps, using `RLock` everywhere else.

This still means though that the lock is shared across each of the different metric types despite them living in separate maps. By splitting up this mutex into multiple, we can now have per-metric type locks, further reducing contention. This does make the bookkeeping slightly more painful, though, but significantly improves throughput, as can be seen in the following benchmarks.

With the single `sync.Mutex`:
```
→ go test -bench=. -benchtime=5s
BenchmarkStore_MutexContention-8   	30000000	       260 ns/op
```
With per metric-type `sync.RWMutex`:
```
→ go test -bench=. -benchtime=5s
BenchmarkStore_MutexContention-8   	50000000	       183 ns/op
```
That's about a 40% improvement. 


---

Of course, most people end up caching the individual metrics the first time they are pulled off the scope, which avoids this contention issue entirely. However, in cases where the metrics are a bit more dynamic (such as when using tags), this improves that.