### PR TITLE
Reduce allocations in tag serialization

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -1,8 +1,14 @@
 package stats
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
+)
+
+const (
+	tagPrefix = ".__"
+	tagSep    = "="
 )
 
 type tagPair struct {
@@ -17,15 +23,15 @@ func (t tagSet) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
 func (t tagSet) Less(i, j int) bool { return t[i].dimension < t[j].dimension }
 
 func serializeTags(tags map[string]string) string {
-	tagPairs := make([]tagPair, 0)
+	tagPairs := make([]tagPair, 0, len(tags))
 	for tagKey, tagValue := range tags {
 		tagPairs = append(tagPairs, tagPair{tagKey, tagValue})
 	}
-
 	sort.Sort(tagSet(tagPairs))
-	var output string
+
+	buf := new(bytes.Buffer)
 	for _, tag := range tagPairs {
-		output = fmt.Sprintf("%s.__%s=%s", output, tag.dimension, tag.value)
+		fmt.Fprint(buf, tagPrefix, tag.dimension, tagSep, tag.value)
 	}
-	return output
+	return buf.String()
 }


### PR DESCRIPTION
Avoiding allocations on the tagPairs slice (since it was initialized with a len of 0) as well as using a `bytes.Buffer` for the concatenation.