### PR TITLE
Update glide and Fix Logrus rename problem

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,17 @@
-hash: 097ae50f09f700b31fb712b8346a3513e7c4d32b22a27d47e5c855cdcf8a1291
-updated: 2017-07-06T13:56:11.128392389-07:00
+hash: 5f6a20dfcbd0d3f8669061128596d7b554934928a05f38a7e8d385c9c78b82d8
+updated: 2017-08-28T01:16:37.227752883+02:00
 imports:
 - name: github.com/kelseyhightower/envconfig
-  version: ac12b1f15efba734211a556d8b125110dc538016
-- name: github.com/Sirupsen/logrus
-  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
+  version: f611eb38b3875cc3bd991ca91c51d06446afa14c
+- name: github.com/sirupsen/logrus
+  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
+- name: golang.org/x/crypto
+  version: 81e90905daefcd6fd217b62423c0908922eadb30
+  subpackages:
+  - ssh/terminal
 - name: golang.org/x/sys
-  version: 9bb9f0998d48b31547d975974935ae9b48c7a03c
+  version: d8f5ea21b9295e315e612b4bcf4bedea93454d4d
   subpackages:
   - unix
+  - windows
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
 package: github.com/lyft/gostats
 import:
 - package: github.com/sirupsen/logrus
-  version: ~0.11.0
+  version: ~1.0.3

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
 package: github.com/lyft/gostats
 import:
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
   version: ~0.11.0

--- a/logging_sink.go
+++ b/logging_sink.go
@@ -1,6 +1,6 @@
 package stats
 
-import logger "github.com/Sirupsen/logrus"
+import logger "github.com/sirupsen/logrus"
 
 type loggingSink struct{}
 

--- a/stats.go
+++ b/stats.go
@@ -8,7 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	logger "github.com/Sirupsen/logrus"
+	logger "github.com/sirupsen/logrus"
 )
 
 // A Store holds statistics.

--- a/tcp_sink.go
+++ b/tcp_sink.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	logger "github.com/Sirupsen/logrus"
+	logger "github.com/sirupsen/logrus"
 )
 
 const (


### PR DESCRIPTION
The logrus repository was renamed from `github.com/Sirupsen/logrus` to `github.com/sirupsen/logrus`. This Pull Request fix the imports to use the newer path and update the glide file.

ref.: https://github.com/sirupsen/logrus/issues/570