### PR TITLE
Add additional timespan functionality

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -143,6 +143,9 @@ type Timer interface {
 
 	// AllocateSpan allocates a Timespan.
 	AllocateSpan() Timespan
+
+	// AllocateSpanElapsed allocates a Timespan which started sometime before.
+	AllocateSpanElapsed(int64) Timespan
 }
 
 // A Timespan is used to measure spans of time.
@@ -277,6 +280,10 @@ func (t *timer) AddValue(value float64) {
 
 func (t *timer) AllocateSpan() Timespan {
 	return &timespan{timer: t, start: time.Now()}
+}
+
+func (t *timer) AllocateSpanElapsed(elapsedTime int64) Timespan {
+	return &timespan{timer: t, start: time.Now().Add(time.Duration(-elapsedTime))}
 }
 
 type timespan struct {


### PR DESCRIPTION
Allows a timespan to be set which started before the current call of timespan. Used for cases where you want to call `NewTimerWithTags` for a snippet of code for which you do not have the tag values at the start of the snippet.