### PR TITLE
Improve statsd sink performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
   - 1.7
   - 1.8
   - 1.9
+  - "1.10"
 
 before_install: mkdir -p $GOPATH/bin
 install:        make install

--- a/tcp_sink.go
+++ b/tcp_sink.go
@@ -120,7 +120,7 @@ func (s *tcpStatsdSink) run() {
 				if err != nil {
 					s.handleFlushError(err, len(buf))
 				} else {
-					s.handleFlushError(fmt.Errorf("Short write to statsd. Resetting connection."), len(buf)-n)
+					s.handleFlushError(fmt.Errorf("short write to statsd, resetting connection"), len(buf)-n)
 				}
 				s.mu.Unlock()
 				_ = s.conn.Close() // Ignore close failures

--- a/tcp_sink.go
+++ b/tcp_sink.go
@@ -55,7 +55,9 @@ type sinkWriter struct {
 func (w sinkWriter) Write(p []byte) (int, error) {
 	n := len(p)
 	pCopy := w.bufPool.Get().([]byte)
-	copy(pCopy, p)
+	if copy(pCopy, p) != len(p) {
+		panic("didn't copy all bytes! bufPool buffers are the wrong length")
+	}
 	select {
 	case w.outc <- pCopy:
 		return n, nil


### PR DESCRIPTION
This vastly reduces the number of syscalls (tcp sends) done by the sink while keeping the syscalls off the critical path of sink clients.
Clients instead share a buffered writer that flushes its buffer to a separate sender goroutine. That goroutine also flushes the buffered writer once per second to ensure that stats continue flowing even if there's a low volume.
Another large resulting perf benefit comes from a reduction in scheduler ping-pong because the clients don't wake up the sender on every metric write.