### PR TITLE
periodic flush

### DIFF
--- a/tcp_sink.go
+++ b/tcp_sink.go
@@ -76,12 +76,12 @@ func (s *tcpStatsdSink) FlushTimer(name string, value float64) {
 func (s *tcpStatsdSink) run() {
 	settings := GetSettings()
 	var writer *bufio.Writer
-	var err error
 
 	idleFlusher := time.NewTimer(flushInterval)
 	defer idleFlusher.Stop()
 	for {
 		if s.conn == nil {
+			var err error
 			s.conn, err = net.Dial("tcp", fmt.Sprintf("%s:%d", settings.StatsdHost,
 				settings.StatsdPort))
 			if err != nil {


### PR DESCRIPTION
This PR implements a fix for the overeager `Flush()` that @jsedgwick tracked down during his recent performance investigations. Now Flush occurs every 64 KB or 1 second, whichever comes first.

To keep things simple, we do not perform the timer-reset-dance if a `WriteString` call results in a `Flush`. This means that sometimes the timer will trigger a Flush when it isn't strictly necessary. However, I consider this just the cost of doing business. 🤷‍♀️ 