### PR TITLE
tags: validate tag values.

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -3,13 +3,18 @@ package stats
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"sort"
 )
 
 const (
-	tagPrefix = ".__"
-	tagSep    = "="
+	tagPrefix   = ".__"
+	tagSep      = "="
+	tagFailsafe = "_"
 )
+
+// illegalTagValueChars are loosely set to ensure we don't have statsd parse errors.
+var illegalTagValueChars = regexp.MustCompile(`[:|]`)
 
 type tagPair struct {
 	dimension string
@@ -25,6 +30,7 @@ func (t tagSet) Less(i, j int) bool { return t[i].dimension < t[j].dimension }
 func serializeTags(tags map[string]string) string {
 	tagPairs := make([]tagPair, 0, len(tags))
 	for tagKey, tagValue := range tags {
+		tagValue = illegalTagValueChars.ReplaceAllLiteralString(tagValue, tagFailsafe)
 		tagPairs = append(tagPairs, tagPair{tagKey, tagValue})
 	}
 	sort.Sort(tagSet(tagPairs))

--- a/tags_test.go
+++ b/tags_test.go
@@ -19,3 +19,11 @@ func TestSerializeWithPerInstanceFlag(t *testing.T) {
 		t.Errorf("Serialized output (%s) didn't match expected output", serialized)
 	}
 }
+
+func TestSerializeIllegalTags(t *testing.T) {
+	tags := map[string]string{"foo": "b|a:r", "q": "p"}
+	serialized := serializeTags(tags)
+	if serialized != ".__foo=b_a_r.__q=p" {
+		t.Errorf("Serialized output (%s) didn't match expected output", serialized)
+	}
+}


### PR DESCRIPTION
This makes sure that | and : are not sent in as tag values, which causes
statsd parse errors, since | and : are delimiters in the statsd format.

This is the most conservative approach in validation, and I think it
makes sense because people tend to send unchecked input in as tag
values. There are stricter rules for metric names and tag keys (at least
in wavefront[1]) but rather than silently changing those, we should let
them fail and cause alerts as they currently do.

[1] https://docs.wavefront.com/wavefront_data_format.html