### PR TITLE
scope: add ScopeWithTags() method.

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -28,6 +28,9 @@ func (t tagSet) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
 func (t tagSet) Less(i, j int) bool { return t[i].dimension < t[j].dimension }
 
 func serializeTags(tags map[string]string) string {
+	if len(tags) == 0 {
+		return ""
+	}
 	tagPairs := make([]tagPair, 0, len(tags))
 	for tagKey, tagValue := range tags {
 		tagValue = illegalTagValueChars.ReplaceAllLiteralString(tagValue, tagFailsafe)


### PR DESCRIPTION
This adds a `ScopeWithTags()` method that allows the caller to set
default tags on the scope. Child scopes and metrics will inherit default
tags from parents, but can still override them.

Implementation note: I reshuffled all of the non-`WithTags` methods to
delegate to `WithTags` methods to ensure the default tags are always
considered.