### PR TITLE
convert periods in tag values to underscore

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -14,7 +14,7 @@ const (
 )
 
 // illegalTagValueChars are loosely set to ensure we don't have statsd parse errors.
-var illegalTagValueChars = regexp.MustCompile(`[:|]`)
+var illegalTagValueChars = regexp.MustCompile(`[:|.]`)
 
 type tagPair struct {
 	dimension string

--- a/tags_test.go
+++ b/tags_test.go
@@ -27,3 +27,11 @@ func TestSerializeIllegalTags(t *testing.T) {
 		t.Errorf("Serialized output (%s) didn't match expected output", serialized)
 	}
 }
+
+func TestSerializeTagValuePeriod(t *testing.T) {
+	tags := map[string]string{"foo": "blah.blah", "q": "p"}
+	serialized := serializeTags(tags)
+	if serialized != ".__foo=blah_blah.__q=p" {
+		t.Errorf("Serialized output (%s) didn't match expected output", serialized)
+	}
+}


### PR DESCRIPTION
This PR makes it so that gostats will mimic `python-lyft-stats` behavior, where periods in tag values are converted to underscore.

Currently is `.` is emitted in a tag value, it breaks the tags. This is a simple fix to convert `.` to `_` so that wavefrontproxy can correctly get the tag value from the metric name