### PR TITLE
scopes: fix bug with tag inheritance.

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -507,7 +507,7 @@ func (s *statStore) NewPerInstanceTimer(name string, tags map[string]string) Tim
 }
 
 func (s subScope) Scope(name string) Scope {
-	return &subScope{registry: s.registry, name: fmt.Sprintf("%s.%s", s.name, name)}
+	return s.ScopeWithTags(name, nil)
 }
 
 func (s subScope) ScopeWithTags(name string, tags map[string]string) Scope {

--- a/tcp_sink_test.go
+++ b/tcp_sink_test.go
@@ -293,15 +293,16 @@ func TestScopesWithTags(t *testing.T) {
 
 	ascope := store.ScopeWithTags("a", map[string]string{"x": "a", "y": "a"})
 	bscope := ascope.ScopeWithTags("b", map[string]string{"x": "b", "z": "b"})
-	counter := bscope.NewCounter("c")
+	dscope := bscope.Scope("d")
+	counter := dscope.NewCounter("c")
 	counter.Inc()
-	timer := bscope.NewTimer("t")
+	timer := dscope.NewTimer("t")
 	timer.AddValue(1)
-	gauge := bscope.NewGauge("g")
+	gauge := dscope.NewGauge("g")
 	gauge.Set(1)
 	store.Flush()
 
-	expected := "a.b.t.__x=b.__y=a.__z=b:1.000000|ms\na.b.c.__x=b.__y=a.__z=b:1|c\na.b.g.__x=b.__y=a.__z=b:1|g\n"
+	expected := "a.b.d.t.__x=b.__y=a.__z=b:1.000000|ms\na.b.d.c.__x=b.__y=a.__z=b:1|c\na.b.d.g.__x=b.__y=a.__z=b:1|g\n"
 	if expected != sink.record {
 		t.Errorf("Expected: '%s' Got: '%s'", expected, sink.record)
 	}
@@ -321,7 +322,7 @@ func TestScopesAndMetricsWithTags(t *testing.T) {
 	gauge.Set(1)
 	store.Flush()
 
-	expected := "a.b.t.__x=m.__z=m:1.000000|ms\na.b.c.__x=m.__z=m:1|c\na.b.g.__x=m.__z=m:1|g\n"
+	expected := "a.b.t.__x=m.__y=a.__z=m:1.000000|ms\na.b.c.__x=m.__y=a.__z=m:1|c\na.b.g.__x=m.__y=a.__z=m:1|g\n"
 	if expected != sink.record {
 		t.Errorf("Expected: '%s' Got: '%s'", expected, sink.record)
 	}


### PR DESCRIPTION
A new untagged scope did not correctly inherit its parents tags.