### PR TITLE
Fix golint import path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ glide: # ensure the glide package tool is installed
 
 .PHONY: lint
 lint: #lints the package for common code smells
-	which golint || go get -u github.com/golang/lint/golint
+	which golint || go get -u golang.org/x/lint/golint
 	test -z "$(gofmt -d -s ./*.go)" || (gofmt -d -s ./*.go && exit 1)
 	golint -set_exit_status
 	go tool vet -all -shadow -shadowstrict *.go


### PR DESCRIPTION
The golint repo has moved to golang.org/x/lint and the import path is
now enforced via an "import comment" this will cause `make lint` to fail.

For more info about "import comments" see:
  https://golang.org/cmd/go/#hdr-Import_path_checking