### PR TITLE
Drop support for Go 1.7 and 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo:     required
 language: go
 go:
-  - 1.7
-  - 1.8
   - 1.9
   - "1.10"
 


### PR DESCRIPTION
The Travis CI build was failing in master due to golint not supporting Go 1.8 any longer.

See this PR https://github.com/golang/lint/issues/421
> Go 1.8 is no longer supported by the Go team. We only support the current release and one previous. Thanks.

fixes #48 