### PR TITLE
Improve the performance of New* methods and tcpStatsdSink

### DIFF
--- a/null_sink.go
+++ b/null_sink.go
@@ -4,11 +4,11 @@ type nullSink struct{}
 
 // NewNullSink returns a Sink that does not have a backing store attached to it.
 func NewNullSink() Sink {
-	return &nullSink{}
+	return nullSink{}
 }
 
-func (s *nullSink) FlushCounter(name string, value uint64) {}
+func (s nullSink) FlushCounter(name string, value uint64) {}
 
-func (s *nullSink) FlushGauge(name string, value uint64) {}
+func (s nullSink) FlushGauge(name string, value uint64) {}
 
-func (s *nullSink) FlushTimer(name string, value float64) {}
+func (s nullSink) FlushTimer(name string, value float64) {}

--- a/stats.go
+++ b/stats.go
@@ -388,8 +388,7 @@ func (s *statStore) NewCounter(name string) Counter {
 }
 
 func (s *statStore) NewCounterWithTags(name string, tags map[string]string) Counter {
-	serializedTags := serializeTags(tags)
-	name = fmt.Sprintf("%s%s", name, serializedTags)
+	name += serializeTags(tags)
 
 	s.countersMtx.RLock()
 	c, ok := s.counters[name]
@@ -433,8 +432,7 @@ func (s *statStore) NewGauge(name string) Gauge {
 }
 
 func (s *statStore) NewGaugeWithTags(name string, tags map[string]string) Gauge {
-	serializedTags := serializeTags(tags)
-	name = fmt.Sprintf("%s%s", name, serializedTags)
+	name += serializeTags(tags)
 
 	s.gaugesMtx.RLock()
 	g, ok := s.gauges[name]
@@ -474,8 +472,7 @@ func (s *statStore) NewTimer(name string) Timer {
 }
 
 func (s *statStore) NewTimerWithTags(name string, tags map[string]string) Timer {
-	serializedTags := serializeTags(tags)
-	name = fmt.Sprintf("%s%s", name, serializedTags)
+	name += serializeTags(tags)
 
 	s.timersMtx.RLock()
 	t, ok := s.timers[name]

--- a/stats_test.go
+++ b/stats_test.go
@@ -68,3 +68,21 @@ func BenchmarkStore_MutexContention(b *testing.B) {
 		bmVal = c.Value()
 	}
 }
+
+func BenchmarkStore_NewCounterWithTags(b *testing.B) {
+	s := NewStore(&nullSink{}, false)
+	t := time.NewTicker(1 * time.Second) // we want flush to contend with accessing metrics
+	defer t.Stop()
+	go s.Start(t)
+	tags := map[string]string{
+		"tag1": "val1",
+		"tag2": "val2",
+		"tag3": "val3",
+		"tag4": "val4",
+		"tag5": "val5",
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.NewCounterWithTags("counter_name", tags)
+	}
+}

--- a/tags.go
+++ b/tags.go
@@ -3,6 +3,7 @@ package stats
 import (
 	"sort"
 	"strings"
+	"unsafe"
 )
 
 // illegalTagValueChars are loosely set to ensure we don't have statsd parse errors.
@@ -41,13 +42,13 @@ func serializeTags(tags map[string]string) string {
 	}
 	sort.Sort(tagSet(pairs))
 
-	var w strings.Builder
-	w.Grow(n)
+	// CEV: this is same as strings.Builder, but works with go1.9 and earlier
+	b := make([]byte, 0, n)
 	for _, tag := range pairs {
-		w.WriteString(prefix)
-		w.WriteString(tag.dimension)
-		w.WriteString(sep)
-		w.WriteString(tag.value)
+		b = append(b, prefix...)
+		b = append(b, tag.dimension...)
+		b = append(b, sep...)
+		b = append(b, tag.value...)
 	}
-	return w.String()
+	return *(*string)(unsafe.Pointer(&b))
 }

--- a/tags_test.go
+++ b/tags_test.go
@@ -35,3 +35,17 @@ func TestSerializeTagValuePeriod(t *testing.T) {
 		t.Errorf("Serialized output (%s) didn't match expected output", serialized)
 	}
 }
+
+func BenchmarkSerializeTags(b *testing.B) {
+	tags := map[string]string{
+		"tag1": "val1",
+		"tag2": "val2",
+		"tag3": "val3",
+		"tag4": "val4",
+		"tag5": "val5",
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		serializeTags(tags)
+	}
+}


### PR DESCRIPTION
I was looking at this repo and had some time to kill so made some small 

* `serializeTags`: use `strings.Replacer` instead of a regex, use `strings.Builder` and calculate size instead of `bytes.Buffer`
* Don't use `fmt.Sprint()` to concatenate strings: `string1 + string2` is much faster.
* `tcpStatsdSink`: make `sync.Pool` global and shared instead of local to each instance of `tcpStatsdSink` - this is the correct usage since `sync.Pool` is essentially "thread local" (see: [`poolLocalInternal`](https://github.com/golang/go/blob/master/src/sync/pool.go#L56-L61) and [`P`](https://github.com/golang/go/blob/master/src/runtime/proc.go#L22)).
* `tcpStatsdSink.mu`: there is no need for the mutex to be a pointer here - instead give `sync.NewCond()` a reference to it.  The rationale here is that we check this often - so skipping the extra pointer dereference is worth it (additionally, `tcpStatsdSink.flushCond` does not need to be a mutex).
* `nullSink`: is of type `struct{}` it does not need to be pointer.

Benchmark results:
```
benchmark                               old ns/op     new ns/op     delta
BenchmarkStore_MutexContention-8        251           121           -51.79%
BenchmarkStore_NewCounterWithTags-8     2878          571           -80.16%
BenchmarkSerializeTags-8                2596          481           -81.47%

benchmark                               old allocs     new allocs     delta
BenchmarkStore_MutexContention-8        2              0              -100.00%
BenchmarkStore_NewCounterWithTags-8     32             4              -87.50%
BenchmarkSerializeTags-8                29             3              -89.66%

benchmark                               old bytes     new bytes     delta
BenchmarkStore_MutexContention-8        22            2             -90.91%
BenchmarkStore_NewCounterWithTags-8     800           336           -58.00%
BenchmarkSerializeTags-8                688           256           -62.79%
```