### PR TITLE
NewGaugeWithTags: re-check condition after acquiring write mutex

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -392,8 +392,7 @@ func (s *statStore) NewCounterWithTags(name string, tags map[string]string) Coun
 	}
 
 	s.countersMtx.Lock()
-	c, ok = s.counters[name]
-	if ok {
+	if c, ok = s.counters[name]; ok {
 		s.countersMtx.Unlock()
 		return c
 	}
@@ -436,7 +435,7 @@ func (s *statStore) NewGaugeWithTags(name string, tags map[string]string) Gauge 
 	}
 
 	s.gaugesMtx.Lock()
-	if g, ok := s.gauges[name]; ok {
+	if g, ok = s.gauges[name]; ok {
 		s.gaugesMtx.Unlock()
 		return g
 	}

--- a/stats.go
+++ b/stats.go
@@ -446,11 +446,11 @@ func (s *statStore) NewGaugeWithTags(name string, tags map[string]string) Gauge 
 
 	s.gaugesMtx.Lock()
 	s.gauges[name] = g
-	s.gaugesMtx.Unlock()
 
 	if s.export && expvar.Get(name) == nil {
 		expvar.Publish(name, g)
 	}
+	s.gaugesMtx.Unlock()
 
 	return g
 }

--- a/stats.go
+++ b/stats.go
@@ -401,7 +401,7 @@ func (s *statStore) NewCounterWithTags(name string, tags map[string]string) Coun
 	c = &counter{}
 	s.counters[name] = c
 	s.countersMtx.Unlock()
-	if s.export {
+	if s.export && expvar.Get(name) == nil {
 		expvar.Publish(name, c)
 	}
 
@@ -444,7 +444,7 @@ func (s *statStore) NewGaugeWithTags(name string, tags map[string]string) Gauge 
 	g = &gauge{}
 	s.gauges[name] = g
 	s.gaugesMtx.Unlock()
-	if s.export {
+	if s.export && expvar.Get(name) == nil {
 		expvar.Publish(name, g)
 	}
 


### PR DESCRIPTION
was getting small number of panics on deploys in our service originating in this method: https://kibana.lyft.net/app/kibana#/doc/elasticlogs*:search-logs/elasticlogssat4:active-logs-003109/go_json?id=0caH%26kPZL%3Dsw%7D(tU%7DTP9&_g=h@6113a49

