### PR TITLE
tags: improve performance for small tag sets

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -558,7 +558,7 @@ func (s subScope) mergeTags(tags map[string]string) map[string]string {
 	if len(s.tags) == 0 {
 		return tags
 	}
-	if tags == nil {
+	if len(tags) == 0 {
 		return s.tags
 	}
 	for k, v := range s.tags {

--- a/tags.go
+++ b/tags.go
@@ -2,15 +2,7 @@ package stats
 
 import (
 	"sort"
-	"strings"
 	"unsafe"
-)
-
-// illegalTagValueChars are loosely set to ensure we don't have statsd parse errors.
-var illegalTagValueCharsReplacer = strings.NewReplacer(
-	".", "_",
-	":", "_",
-	"|", "_",
 )
 
 type tagPair struct {
@@ -28,32 +20,67 @@ func serializeTags(name string, tags map[string]string) string {
 	const prefix = ".__"
 	const sep = "="
 
-	if len(tags) == 0 {
+	// switch len(tags) {
+	switch len(tags) {
+	case 0:
 		return name
-	}
+	case 1:
+		for k, v := range tags {
+			return name + prefix + k + sep + replaceChars(v)
+		}
+		panic("unreachable")
+	case 2:
+		var a, b tagPair
+		for k, v := range tags {
+			b = a
+			a = tagPair{k, replaceChars(v)}
+		}
+		if a.dimension > b.dimension {
+			a, b = b, a
+		}
+		return name + prefix + a.dimension + sep + a.value +
+			prefix + b.dimension + sep + b.value
+	default:
+		// n stores the length of the serialized name + tags
+		n := (len(prefix) + len(sep)) * len(tags)
+		n += len(name)
 
-	// n stores the length of the serialized name + tags
-	n := (len(prefix) + len(sep)) * len(tags)
-	n += len(name)
+		pairs := make(tagSet, 0, len(tags))
+		for k, v := range tags {
+			n += len(k) + len(v)
+			pairs = append(pairs, tagPair{
+				dimension: k,
+				value:     replaceChars(v),
+			})
+		}
+		sort.Sort(pairs)
 
-	pairs := make([]tagPair, 0, len(tags))
-	for k, v := range tags {
-		n += len(k) + len(v)
-		pairs = append(pairs, tagPair{
-			dimension: k,
-			value:     illegalTagValueCharsReplacer.Replace(v),
-		})
+		// CEV: this is same as strings.Builder, but works with go1.9 and earlier
+		b := make([]byte, 0, n)
+		b = append(b, name...)
+		for _, tag := range pairs {
+			b = append(b, prefix...)
+			b = append(b, tag.dimension...)
+			b = append(b, sep...)
+			b = append(b, tag.value...)
+		}
+		return *(*string)(unsafe.Pointer(&b))
 	}
-	sort.Sort(tagSet(pairs))
+}
 
-	// CEV: this is same as strings.Builder, but works with go1.9 and earlier
-	b := make([]byte, 0, n)
-	b = append(b, name...)
-	for _, tag := range pairs {
-		b = append(b, prefix...)
-		b = append(b, tag.dimension...)
-		b = append(b, sep...)
-		b = append(b, tag.value...)
+func replaceChars(s string) string {
+	var buf []byte // lazily allocated
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '.', ':', '|':
+			if buf == nil {
+				buf = []byte(s)
+			}
+			buf[i] = '_'
+		}
 	}
-	return *(*string)(unsafe.Pointer(&b))
+	if buf == nil {
+		return s
+	}
+	return string(buf)
 }

--- a/tags_test.go
+++ b/tags_test.go
@@ -10,7 +10,8 @@ func TestSerializeTags(t *testing.T) {
 	tags := map[string]string{"zzz": "hello", "q": "r"}
 	serialized := serializeTags(name, tags)
 	if serialized != expected {
-		t.Errorf("Serialized output (%s) didn't match expected output", serialized)
+		t.Errorf("Serialized output (%s) didn't match expected output: %s",
+			serialized, expected)
 	}
 }
 
@@ -20,7 +21,8 @@ func TestSerializeWithPerInstanceFlag(t *testing.T) {
 	tags := map[string]string{"foo": "bar", "_f": "i"}
 	serialized := serializeTags(name, tags)
 	if serialized != expected {
-		t.Errorf("Serialized output (%s) didn't match expected output", serialized)
+		t.Errorf("Serialized output (%s) didn't match expected output: %s",
+			serialized, expected)
 	}
 }
 
@@ -30,7 +32,8 @@ func TestSerializeIllegalTags(t *testing.T) {
 	tags := map[string]string{"foo": "b|a:r", "q": "p"}
 	serialized := serializeTags(name, tags)
 	if serialized != expected {
-		t.Errorf("Serialized output (%s) didn't match expected output", serialized)
+		t.Errorf("Serialized output (%s) didn't match expected output: %s",
+			serialized, expected)
 	}
 }
 
@@ -40,7 +43,8 @@ func TestSerializeTagValuePeriod(t *testing.T) {
 	tags := map[string]string{"foo": "blah.blah", "q": "p"}
 	serialized := serializeTags(name, tags)
 	if serialized != expected {
-		t.Errorf("Serialized output (%s) didn't match expected output", serialized)
+		t.Errorf("Serialized output (%s) didn't match expected output: %s",
+			serialized, expected)
 	}
 }
 
@@ -52,6 +56,29 @@ func BenchmarkSerializeTags(b *testing.B) {
 		"tag3": "val3",
 		"tag4": "val4",
 		"tag5": "val5",
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		serializeTags(name, tags)
+	}
+}
+
+func BenchmarkSerializeTags_One(b *testing.B) {
+	const name = "prefix"
+	tags := map[string]string{
+		"tag1": "val1",
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		serializeTags(name, tags)
+	}
+}
+
+func BenchmarkSerializeTags_Two(b *testing.B) {
+	const name = "prefix"
+	tags := map[string]string{
+		"tag1": "val1",
+		"tag2": "val2",
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
TLDR: I had some time to kill on flight last week and noticed that many tag operations occur with 1 or 2 tags - so I made that roughly ~40% faster and reduced allocs and memory usage by roughly 2/3, which is what I really care about.

```
benchmark                        old ns/op     new ns/op     delta
BenchmarkSerializeTags-8         444           445           +0.23%
BenchmarkSerializeTags_One-8     162           94.0          -41.98%
BenchmarkSerializeTags_Two-8     237           145           -38.82%

benchmark                        old allocs     new allocs     delta
BenchmarkSerializeTags-8         3              3              +0.00%
BenchmarkSerializeTags_One-8     3              1              -66.67%
BenchmarkSerializeTags_Two-8     3              1              -66.67%

benchmark                        old bytes     new bytes     delta
BenchmarkSerializeTags-8         272           272           +0.00%
BenchmarkSerializeTags_One-8     96            32            -66.67%
BenchmarkSerializeTags_Two-8     128           32            -75.00%
```