### PR TITLE
Add thread-safe mock sink for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ go get github.com/lyft/gostats
 ## Building & Testing
 
 ```sh
-make install 
+make install
 make test
 ```
 
@@ -21,4 +21,60 @@ In order to start using `gostats`, import it into your project with:
 
 ```go
 import "github.com/lyft/gostats"
+```
+
+
+## Mocking
+
+A thread-safe mock sink is provided by the [gostats/mock](https://github.com/lyft/gostats/blob/mock-sink/mock/sink.go) package.  The mock sink also provides methods that are useful for testing (as demonstrated below).
+```go
+package mock_test
+
+import (
+	"testing"
+
+	"github.com/lyft/gostats"
+	"github.com/lyft/gostats/mock"
+)
+
+type Config struct {
+	Stats stats.Store
+}
+
+func TestMockExample(t *testing.T) {
+	sink := mock.NewSink()
+	conf := Config{
+		Stats: stats.NewStore(sink, false),
+	}
+	conf.Stats.NewCounter("name").Inc()
+	conf.Stats.Flush()
+	sink.AssertCounterEquals(t, "name", 1)
+}
+```
+
+If you do not need to assert on the contents of the sink the below example can be used to quickly create a thread-safe `stats.Scope`:
+```go
+package config
+
+import (
+	"github.com/lyft/gostats"
+	"github.com/lyft/gostats/mock"
+)
+
+type Config struct {
+	Stats stats.Store
+}
+
+func NewConfig() *Config {
+	return &Config{
+		Stats: stats.NewDefaultStore(),
+	}
+}
+
+func NewMockConfig() *Config {
+	sink := mock.NewSink()
+	return &Config{
+		Stats: stats.NewStore(sink, false),
+	}
+}
 ```

--- a/mock/sink.go
+++ b/mock/sink.go
@@ -1,0 +1,298 @@
+package mock
+
+import (
+	"math"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+type value struct {
+	val   uint64
+	count int64
+}
+
+// A Sink is a mock sink meant for testing that is safe for concurrent use.
+type Sink struct {
+	counters sync.Map
+	timers   sync.Map
+	gauges   sync.Map
+	mu       sync.RWMutex
+}
+
+func NewSink() *Sink {
+	return new(Sink)
+}
+
+// Flush is a no-op method
+func (*Sink) Flush() {}
+
+func (s *Sink) Reset() {
+	s.mu.Lock()
+	s.counters = sync.Map{}
+	s.timers = sync.Map{}
+	s.gauges = sync.Map{}
+	s.mu.Unlock()
+}
+
+func (s *Sink) FlushCounter(name string, val uint64) {
+	s.mu.RLock()
+	v, ok := s.counters.Load(name)
+	if !ok {
+		v, _ = s.counters.LoadOrStore(name, new(value))
+	}
+	s.mu.RUnlock()
+	p := v.(*value)
+	atomic.AddUint64(&p.val, val)
+	atomic.AddInt64(&p.count, 1)
+}
+
+func (s *Sink) FlushGauge(name string, val uint64) {
+	s.mu.RLock()
+	v, ok := s.gauges.Load(name)
+	if !ok {
+		v, _ = s.gauges.LoadOrStore(name, new(value))
+	}
+	s.mu.RUnlock()
+	p := v.(*value)
+	atomic.AddUint64(&p.val, val)
+	atomic.AddInt64(&p.count, 1)
+}
+
+func atomicAddFloat64(dest *uint64, delta float64) {
+	for {
+		cur := atomic.LoadUint64(dest)
+		curVal := math.Float64frombits(cur)
+		nxtVal := curVal + delta
+		nxt := math.Float64bits(nxtVal)
+		if atomic.CompareAndSwapUint64(dest, cur, nxt) {
+			return
+		}
+	}
+}
+
+func (s *Sink) FlushTimer(name string, val float64) {
+	s.mu.RLock()
+	v, ok := s.timers.Load(name)
+	if !ok {
+		v, _ = s.timers.LoadOrStore(name, new(value))
+	}
+	s.mu.RUnlock()
+	p := v.(*value)
+	atomicAddFloat64(&p.val, val)
+	atomic.AddInt64(&p.count, 1)
+}
+
+func (s *Sink) LoadCounter(name string) (uint64, bool) {
+	s.mu.RLock()
+	v, ok := s.counters.Load(name)
+	s.mu.RUnlock()
+	if ok {
+		p := v.(*value)
+		return atomic.LoadUint64(&p.val), true
+	}
+	return 0, false
+}
+
+func (s *Sink) LoadGauge(name string) (uint64, bool) {
+	s.mu.RLock()
+	v, ok := s.gauges.Load(name)
+	s.mu.RUnlock()
+	if ok {
+		p := v.(*value)
+		return atomic.LoadUint64(&p.val), true
+	}
+	return 0, false
+}
+
+func (s *Sink) LoadTimer(name string) (float64, bool) {
+	s.mu.RLock()
+	v, ok := s.timers.Load(name)
+	s.mu.RUnlock()
+	if ok {
+		p := v.(*value)
+		bits := atomic.LoadUint64(&p.val)
+		return math.Float64frombits(bits), true
+	}
+	return 0, false
+}
+
+// short-hand methods
+
+func (s *Sink) Counter(name string) uint64 {
+	v, _ := s.LoadCounter(name)
+	return v
+}
+
+func (s *Sink) Gauge(name string) uint64 {
+	v, _ := s.LoadGauge(name)
+	return v
+}
+
+func (s *Sink) Timer(name string) float64 {
+	v, _ := s.LoadTimer(name)
+	return v
+}
+
+// these methods are mostly useful for testing
+
+func (s *Sink) CounterCallCount(name string) int64 {
+	s.mu.RLock()
+	v, ok := s.counters.Load(name)
+	s.mu.RUnlock()
+	if ok {
+		return atomic.LoadInt64(&v.(*value).count)
+	}
+	return 0
+}
+
+func (s *Sink) GaugeCallCount(name string) int64 {
+	s.mu.RLock()
+	v, ok := s.gauges.Load(name)
+	s.mu.RUnlock()
+	if ok {
+		return atomic.LoadInt64(&v.(*value).count)
+	}
+	return 0
+}
+
+func (s *Sink) TimerCallCount(name string) int64 {
+	s.mu.RLock()
+	v, ok := s.timers.Load(name)
+	s.mu.RUnlock()
+	if ok {
+		return atomic.LoadInt64(&v.(*value).count)
+	}
+	return 0
+}
+
+// test helpers
+
+// AssertCounterEquals asserts that Counter name is present and has value exp.
+func (s *Sink) AssertCounterEquals(tb testing.TB, name string, exp uint64) {
+	tb.Helper()
+	u, ok := s.LoadCounter(name)
+	if !ok {
+		tb.Fatalf("gostats/mock: Counter (%q): not found", name)
+	}
+	if u != exp {
+		tb.Fatalf("gostats/mock: Counter (%q): Expected: %d Got: %d", name, exp, u)
+	}
+}
+
+// AssertGaugeEquals asserts that Gauge name is present and has value exp.
+func (s *Sink) AssertGaugeEquals(tb testing.TB, name string, exp uint64) {
+	tb.Helper()
+	u, ok := s.LoadGauge(name)
+	if !ok {
+		tb.Fatalf("gostats/mock: Gauge (%q): not found", name)
+	}
+	if u != exp {
+		tb.Fatalf("gostats/mock: Gauge (%q): Expected: %d Got: %d", name, exp, u)
+	}
+}
+
+// AssertTimerEquals asserts that Timer name is present and has value exp.
+func (s *Sink) AssertTimerEquals(tb testing.TB, name string, exp float64) {
+	tb.Helper()
+	f, ok := s.LoadTimer(name)
+	if !ok {
+		tb.Fatalf("gostats/mock: Timer (%q): not found", name)
+	}
+	if f != exp {
+		tb.Fatalf("gostats/mock: Timer (%q): Expected: %f Got: %f", name, exp, f)
+	}
+}
+
+// AssertCounterExists asserts that Counter name exists.
+func (s *Sink) AssertCounterExists(tb testing.TB, name string) {
+	tb.Helper()
+	if _, ok := s.LoadCounter(name); !ok {
+		tb.Fatalf("gostats/mock: Counter (%q): should exist", name)
+	}
+}
+
+// AssertGaugeExists asserts that Gauge name exists.
+func (s *Sink) AssertGaugeExists(tb testing.TB, name string) {
+	tb.Helper()
+	if _, ok := s.LoadGauge(name); !ok {
+		tb.Fatalf("gostats/mock: Gauge (%q): should exist", name)
+	}
+}
+
+// AssertTimerExists asserts that Timer name exists.
+func (s *Sink) AssertTimerExists(tb testing.TB, name string) {
+	tb.Helper()
+	if _, ok := s.LoadTimer(name); !ok {
+		tb.Fatalf("gostats/mock: Timer (%q): should exist", name)
+	}
+}
+
+// AssertCounterNotExists asserts that Counter name does not exist.
+func (s *Sink) AssertCounterNotExists(tb testing.TB, name string) {
+	tb.Helper()
+	if _, ok := s.LoadCounter(name); ok {
+		tb.Fatalf("gostats/mock: Counter (%q): expected Counter to not exist", name)
+	}
+}
+
+// AssertGaugeNotExists asserts that Gauge name does not exist.
+func (s *Sink) AssertGaugeNotExists(tb testing.TB, name string) {
+	tb.Helper()
+	if _, ok := s.LoadGauge(name); ok {
+		tb.Fatalf("gostats/mock: Gauge (%q): expected Gauge to not exist", name)
+	}
+}
+
+// AssertTimerNotExists asserts that Timer name does not exist.
+func (s *Sink) AssertTimerNotExists(tb testing.TB, name string) {
+	tb.Helper()
+	if _, ok := s.LoadTimer(name); ok {
+		tb.Fatalf("gostats/mock: Timer (%q): expected Timer to not exist", name)
+	}
+}
+
+// AssertCounterCallCount asserts that Counter name was called exp times.
+func (s *Sink) AssertCounterCallCount(tb testing.TB, name string, exp int) {
+	tb.Helper()
+	v, ok := s.counters.Load(name)
+	if !ok {
+		tb.Fatalf("gostats/mock: Counter (%q): not found", name)
+	}
+	p := v.(*value)
+	n := atomic.LoadInt64(&p.count)
+	if n != int64(exp) {
+		tb.Fatalf("gostats/mock: Counter (%q) Call Count: Expected: %d Got: %d",
+			name, exp, n)
+	}
+}
+
+// AssertGaugeCallCount asserts that Gauge name was called exp times.
+func (s *Sink) AssertGaugeCallCount(tb testing.TB, name string, exp int) {
+	tb.Helper()
+	v, ok := s.gauges.Load(name)
+	if !ok {
+		tb.Fatalf("gostats/mock: Gauge (%q): not found", name)
+	}
+	p := v.(*value)
+	n := atomic.LoadInt64(&p.count)
+	if n != int64(exp) {
+		tb.Fatalf("gostats/mock: Gauge (%q) Call Count: Expected: %d Got: %d",
+			name, exp, n)
+	}
+}
+
+// AssertTimerCallCount asserts that Timer name was called exp times.
+func (s *Sink) AssertTimerCallCount(tb testing.TB, name string, exp int) {
+	tb.Helper()
+	v, ok := s.timers.Load(name)
+	if !ok {
+		tb.Fatalf("gostats/mock: Timer (%q): not found", name)
+	}
+	p := v.(*value)
+	n := atomic.LoadInt64(&p.count)
+	if n != int64(exp) {
+		tb.Fatalf("gostats/mock: Timer (%q) Call Count: Expected: %d Got: %d",
+			name, exp, n)
+	}
+}

--- a/mock/sink.go
+++ b/mock/sink.go
@@ -173,10 +173,11 @@ func (s *Sink) AssertCounterEquals(tb testing.TB, name string, exp uint64) {
 	tb.Helper()
 	u, ok := s.LoadCounter(name)
 	if !ok {
-		tb.Fatalf("gostats/mock: Counter (%q): not found", name)
+		tb.Errorf("gostats/mock: Counter (%q): not found", name)
+		return
 	}
 	if u != exp {
-		tb.Fatalf("gostats/mock: Counter (%q): Expected: %d Got: %d", name, exp, u)
+		tb.Errorf("gostats/mock: Counter (%q): Expected: %d Got: %d", name, exp, u)
 	}
 }
 
@@ -185,10 +186,11 @@ func (s *Sink) AssertGaugeEquals(tb testing.TB, name string, exp uint64) {
 	tb.Helper()
 	u, ok := s.LoadGauge(name)
 	if !ok {
-		tb.Fatalf("gostats/mock: Gauge (%q): not found", name)
+		tb.Errorf("gostats/mock: Gauge (%q): not found", name)
+		return
 	}
 	if u != exp {
-		tb.Fatalf("gostats/mock: Gauge (%q): Expected: %d Got: %d", name, exp, u)
+		tb.Errorf("gostats/mock: Gauge (%q): Expected: %d Got: %d", name, exp, u)
 	}
 }
 
@@ -197,10 +199,11 @@ func (s *Sink) AssertTimerEquals(tb testing.TB, name string, exp float64) {
 	tb.Helper()
 	f, ok := s.LoadTimer(name)
 	if !ok {
-		tb.Fatalf("gostats/mock: Timer (%q): not found", name)
+		tb.Errorf("gostats/mock: Timer (%q): not found", name)
+		return
 	}
 	if f != exp {
-		tb.Fatalf("gostats/mock: Timer (%q): Expected: %f Got: %f", name, exp, f)
+		tb.Errorf("gostats/mock: Timer (%q): Expected: %f Got: %f", name, exp, f)
 	}
 }
 
@@ -208,7 +211,7 @@ func (s *Sink) AssertTimerEquals(tb testing.TB, name string, exp float64) {
 func (s *Sink) AssertCounterExists(tb testing.TB, name string) {
 	tb.Helper()
 	if _, ok := s.LoadCounter(name); !ok {
-		tb.Fatalf("gostats/mock: Counter (%q): should exist", name)
+		tb.Errorf("gostats/mock: Counter (%q): should exist", name)
 	}
 }
 
@@ -216,7 +219,7 @@ func (s *Sink) AssertCounterExists(tb testing.TB, name string) {
 func (s *Sink) AssertGaugeExists(tb testing.TB, name string) {
 	tb.Helper()
 	if _, ok := s.LoadGauge(name); !ok {
-		tb.Fatalf("gostats/mock: Gauge (%q): should exist", name)
+		tb.Errorf("gostats/mock: Gauge (%q): should exist", name)
 	}
 }
 
@@ -224,7 +227,7 @@ func (s *Sink) AssertGaugeExists(tb testing.TB, name string) {
 func (s *Sink) AssertTimerExists(tb testing.TB, name string) {
 	tb.Helper()
 	if _, ok := s.LoadTimer(name); !ok {
-		tb.Fatalf("gostats/mock: Timer (%q): should exist", name)
+		tb.Errorf("gostats/mock: Timer (%q): should exist", name)
 	}
 }
 
@@ -232,7 +235,7 @@ func (s *Sink) AssertTimerExists(tb testing.TB, name string) {
 func (s *Sink) AssertCounterNotExists(tb testing.TB, name string) {
 	tb.Helper()
 	if _, ok := s.LoadCounter(name); ok {
-		tb.Fatalf("gostats/mock: Counter (%q): expected Counter to not exist", name)
+		tb.Errorf("gostats/mock: Counter (%q): expected Counter to not exist", name)
 	}
 }
 
@@ -240,7 +243,7 @@ func (s *Sink) AssertCounterNotExists(tb testing.TB, name string) {
 func (s *Sink) AssertGaugeNotExists(tb testing.TB, name string) {
 	tb.Helper()
 	if _, ok := s.LoadGauge(name); ok {
-		tb.Fatalf("gostats/mock: Gauge (%q): expected Gauge to not exist", name)
+		tb.Errorf("gostats/mock: Gauge (%q): expected Gauge to not exist", name)
 	}
 }
 
@@ -248,7 +251,7 @@ func (s *Sink) AssertGaugeNotExists(tb testing.TB, name string) {
 func (s *Sink) AssertTimerNotExists(tb testing.TB, name string) {
 	tb.Helper()
 	if _, ok := s.LoadTimer(name); ok {
-		tb.Fatalf("gostats/mock: Timer (%q): expected Timer to not exist", name)
+		tb.Errorf("gostats/mock: Timer (%q): expected Timer to not exist", name)
 	}
 }
 
@@ -257,12 +260,13 @@ func (s *Sink) AssertCounterCallCount(tb testing.TB, name string, exp int) {
 	tb.Helper()
 	v, ok := s.counters.Load(name)
 	if !ok {
-		tb.Fatalf("gostats/mock: Counter (%q): not found", name)
+		tb.Errorf("gostats/mock: Counter (%q): not found", name)
+		return
 	}
 	p := v.(*entry)
 	n := atomic.LoadInt64(&p.count)
 	if n != int64(exp) {
-		tb.Fatalf("gostats/mock: Counter (%q) Call Count: Expected: %d Got: %d",
+		tb.Errorf("gostats/mock: Counter (%q) Call Count: Expected: %d Got: %d",
 			name, exp, n)
 	}
 }
@@ -272,12 +276,13 @@ func (s *Sink) AssertGaugeCallCount(tb testing.TB, name string, exp int) {
 	tb.Helper()
 	v, ok := s.gauges.Load(name)
 	if !ok {
-		tb.Fatalf("gostats/mock: Gauge (%q): not found", name)
+		tb.Errorf("gostats/mock: Gauge (%q): not found", name)
+		return
 	}
 	p := v.(*entry)
 	n := atomic.LoadInt64(&p.count)
 	if n != int64(exp) {
-		tb.Fatalf("gostats/mock: Gauge (%q) Call Count: Expected: %d Got: %d",
+		tb.Errorf("gostats/mock: Gauge (%q) Call Count: Expected: %d Got: %d",
 			name, exp, n)
 	}
 }
@@ -287,12 +292,13 @@ func (s *Sink) AssertTimerCallCount(tb testing.TB, name string, exp int) {
 	tb.Helper()
 	v, ok := s.timers.Load(name)
 	if !ok {
-		tb.Fatalf("gostats/mock: Timer (%q): not found", name)
+		tb.Errorf("gostats/mock: Timer (%q): not found", name)
+		return
 	}
 	p := v.(*entry)
 	n := atomic.LoadInt64(&p.count)
 	if n != int64(exp) {
-		tb.Fatalf("gostats/mock: Timer (%q) Call Count: Expected: %d Got: %d",
+		tb.Errorf("gostats/mock: Timer (%q) Call Count: Expected: %d Got: %d",
 			name, exp, n)
 	}
 }

--- a/mock/sink.go
+++ b/mock/sink.go
@@ -18,7 +18,8 @@ type Sink struct {
 	counters sync.Map
 	timers   sync.Map
 	gauges   sync.Map
-	mu       sync.RWMutex // reset lock
+	// write held only during Reset(), all map accesses must hold the read lock
+	mu sync.RWMutex
 }
 
 func NewSink() *Sink {

--- a/mock/sink.go
+++ b/mock/sink.go
@@ -18,7 +18,7 @@ type Sink struct {
 	counters sync.Map
 	timers   sync.Map
 	gauges   sync.Map
-	mu       sync.RWMutex
+	mu       sync.RWMutex // reset lock
 }
 
 func NewSink() *Sink {

--- a/mock/sink_interface_test.go
+++ b/mock/sink_interface_test.go
@@ -1,0 +1,9 @@
+package mock_test
+
+import (
+	"github.com/lyft/gostats"
+	"github.com/lyft/gostats/mock"
+)
+
+var _ stats.Sink = (*mock.Sink)(nil)
+var _ stats.FlushableSink = (*mock.Sink)(nil)

--- a/mock/sink_test.go
+++ b/mock/sink_test.go
@@ -4,8 +4,60 @@ import (
 	"math"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 )
+
+func TestSink(t *testing.T) {
+	testCounter := func(t *testing.T, exp uint64, sink *Sink) {
+		t.Helper()
+		const name = "test-counter"
+		sink.FlushCounter(name, exp)
+		sink.AssertCounterEquals(t, name, exp)
+		sink.AssertCounterExists(t, name)
+		sink.AssertCounterCallCount(t, name, 1)
+		if n := sink.Counter(name); n != exp {
+			t.Errorf("Counter(): want: %d got: %d", exp, n)
+		}
+	}
+	testGauge := func(t *testing.T, exp uint64, sink *Sink) {
+		const name = "test-gauge"
+		sink.FlushGauge(name, exp)
+		sink.AssertGaugeEquals(t, name, exp)
+		sink.AssertGaugeExists(t, name)
+		sink.AssertGaugeCallCount(t, name, 1)
+		if n := sink.Gauge(name); n != exp {
+			t.Errorf("Gauge(): want: %d got: %d", exp, n)
+		}
+	}
+	testTimer := func(t *testing.T, exp float64, sink *Sink) {
+		const name = "test-timer"
+		sink.FlushTimer(name, exp)
+		sink.AssertTimerEquals(t, name, exp)
+		sink.AssertTimerExists(t, name)
+		sink.AssertTimerCallCount(t, name, 1)
+		if n := sink.Timer(name); n != exp {
+			t.Errorf("Timer(): want: %f got: %f", exp, n)
+		}
+	}
+	// test 0..1 - we want to make sure that 0 still registers a stat
+	for i := 0; i < 2; i++ {
+		t.Run("Counter", func(t *testing.T) {
+			testCounter(t, uint64(i), NewSink())
+		})
+		t.Run("Gauge", func(t *testing.T) {
+			testGauge(t, uint64(i), NewSink())
+		})
+		t.Run("Timer", func(t *testing.T) {
+			testTimer(t, float64(i), NewSink())
+		})
+		// all together now
+		sink := NewSink()
+		testCounter(t, 1, sink)
+		testGauge(t, 1, sink)
+		testTimer(t, 1, sink)
+	}
+}
 
 func TestFlushTimer(t *testing.T) {
 	sink := NewSink()
@@ -27,7 +79,57 @@ func TestFlushTimer(t *testing.T) {
 	sink.AssertTimerEquals(t, "timer", math.SmallestNonzeroFloat64)
 }
 
-func TestThreadSafeSinkReset(t *testing.T) {
+func TestSink_ThreadSafe(t *testing.T) {
+	const N = 2000
+	sink := NewSink()
+	var (
+		counterCalls = new(int64)
+		gaugeCalls   = new(int64)
+		timerCalls   = new(int64)
+		counterVal   = new(uint64)
+		gaugeVal     = new(uint64)
+	)
+	funcs := [...]func(){
+		func() {
+			atomic.AddInt64(counterCalls, 1)
+			atomic.AddUint64(counterVal, 1)
+			sink.FlushCounter("name", 1)
+		},
+		func() {
+			atomic.AddInt64(gaugeCalls, 1)
+			atomic.AddUint64(gaugeVal, 1)
+			sink.FlushGauge("name", 1)
+		},
+		func() {
+			atomic.AddInt64(timerCalls, 1)
+			sink.FlushTimer("name", 1)
+		},
+	}
+	numCPU := runtime.NumCPU()
+	if numCPU < 2 {
+		numCPU = 2
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < numCPU; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < N; i++ {
+				funcs[i%len(funcs)]()
+			}
+		}()
+	}
+	wg.Wait()
+
+	sink.AssertCounterCallCount(t, "name", int(atomic.LoadInt64(counterCalls)))
+	sink.AssertGaugeCallCount(t, "name", int(atomic.LoadInt64(gaugeCalls)))
+	sink.AssertTimerCallCount(t, "name", int(atomic.LoadInt64(timerCalls)))
+
+	sink.AssertCounterEquals(t, "name", atomic.LoadUint64(counterVal))
+	sink.AssertGaugeEquals(t, "name", atomic.LoadUint64(gaugeVal))
+}
+
+func TestSink_ThreadSafe_Reset(t *testing.T) {
 	const N = 2000
 	sink := NewSink()
 	funcs := [...]func(){

--- a/mock/sink_test.go
+++ b/mock/sink_test.go
@@ -175,3 +175,10 @@ func TestSink_ThreadSafe_Reset(t *testing.T) {
 	wg.Wait()
 	close(done)
 }
+
+// TestFatalExample is an example usage of Fatal()
+func TestFatalExample(t *testing.T) {
+	sink := NewSink()
+	sink.FlushCounter("name", 1)
+	sink.AssertCounterEquals(Fatal(t), "name", 1)
+}

--- a/mock/sink_test.go
+++ b/mock/sink_test.go
@@ -31,6 +31,7 @@ func TestThreadSafeSinkReset(t *testing.T) {
 	const N = 2000
 	sink := NewSink()
 	funcs := [...]func(){
+		func() { sink.Flush() },
 		func() { sink.FlushCounter("name", 1) },
 		func() { sink.FlushGauge("name", 1) },
 		func() { sink.FlushTimer("name", 1) },

--- a/mock/sink_test.go
+++ b/mock/sink_test.go
@@ -27,19 +27,6 @@ func TestFlushTimer(t *testing.T) {
 	sink.AssertTimerEquals(t, "timer", math.SmallestNonzeroFloat64)
 }
 
-// func (s *Sink) FlushCounter(name string, val uint64)
-// func (s *Sink) FlushGauge(name string, val uint64)
-// func (s *Sink) FlushTimer(name string, val float64)
-// func (s *Sink) LoadCounter(name string) (uint64, bool)
-// func (s *Sink) LoadGauge(name string) (uint64, bool)
-// func (s *Sink) LoadTimer(name string) (float64, bool)
-// func (s *Sink) Counter(name string) uint64
-// func (s *Sink) Gauge(name string) uint64
-// func (s *Sink) Timer(name string) float64
-// func (s *Sink) CounterCallCount(name string) int64
-// func (s *Sink) GaugeCallCount(name string) int64
-// func (s *Sink) TimerCallCount(name string) int64
-
 func TestThreadSafeSinkReset(t *testing.T) {
 	const N = 2000
 	sink := NewSink()

--- a/mock/sink_test.go
+++ b/mock/sink_test.go
@@ -1,0 +1,87 @@
+package mock
+
+import (
+	"math"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+func TestFlushTimer(t *testing.T) {
+	sink := NewSink()
+	var exp float64
+	for i := 0; i < 10000; i++ {
+		sink.FlushTimer("timer", 1)
+		exp++
+	}
+	sink.AssertTimerEquals(t, "timer", exp)
+
+	// test limits
+
+	sink.Reset()
+	sink.FlushTimer("timer", math.MaxFloat64)
+	sink.AssertTimerEquals(t, "timer", math.MaxFloat64)
+
+	sink.Reset()
+	sink.FlushTimer("timer", math.SmallestNonzeroFloat64)
+	sink.AssertTimerEquals(t, "timer", math.SmallestNonzeroFloat64)
+}
+
+// func (s *Sink) FlushCounter(name string, val uint64)
+// func (s *Sink) FlushGauge(name string, val uint64)
+// func (s *Sink) FlushTimer(name string, val float64)
+// func (s *Sink) LoadCounter(name string) (uint64, bool)
+// func (s *Sink) LoadGauge(name string) (uint64, bool)
+// func (s *Sink) LoadTimer(name string) (float64, bool)
+// func (s *Sink) Counter(name string) uint64
+// func (s *Sink) Gauge(name string) uint64
+// func (s *Sink) Timer(name string) float64
+// func (s *Sink) CounterCallCount(name string) int64
+// func (s *Sink) GaugeCallCount(name string) int64
+// func (s *Sink) TimerCallCount(name string) int64
+
+func TestThreadSafeSinkReset(t *testing.T) {
+	const N = 2000
+	sink := NewSink()
+	funcs := [...]func(){
+		func() { sink.FlushCounter("name", 1) },
+		func() { sink.FlushGauge("name", 1) },
+		func() { sink.FlushTimer("name", 1) },
+		func() { sink.LoadCounter("name") },
+		func() { sink.LoadGauge("name") },
+		func() { sink.LoadTimer("name") },
+		func() { sink.Counter("name") },
+		func() { sink.Gauge("name") },
+		func() { sink.Timer("name") },
+		func() { sink.CounterCallCount("name") },
+		func() { sink.GaugeCallCount("name") },
+		func() { sink.TimerCallCount("name") },
+	}
+	numCPU := runtime.NumCPU() - 1
+	if numCPU < 2 {
+		numCPU = 2
+	}
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				sink.Reset()
+			}
+		}
+	}()
+	var wg sync.WaitGroup
+	for i := 0; i < numCPU; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < N; i++ {
+				funcs[i%len(funcs)]()
+			}
+		}()
+	}
+	wg.Wait()
+	close(done)
+}

--- a/mock_sink.go
+++ b/mock_sink.go
@@ -2,6 +2,8 @@ package stats
 
 import "sync"
 
+// DEPRECATED: use "github.com/lyft/gostats/mock" instead.
+//
 // MockSink describes an in-memory Sink used for testing.
 type MockSink struct {
 	Counters map[string]uint64
@@ -13,6 +15,8 @@ type MockSink struct {
 	gLock sync.Mutex
 }
 
+// DEPRECATED: use "github.com/lyft/gostats/mock" instead.
+//
 // NewMockSink returns a MockSink that flushes stats to in-memory maps. An
 // instance of MockSink is not safe for concurrent use.
 func NewMockSink() (m *MockSink) {

--- a/mock_sink.go
+++ b/mock_sink.go
@@ -2,9 +2,9 @@ package stats
 
 import "sync"
 
-// DEPRECATED: use "github.com/lyft/gostats/mock" instead.
-//
 // MockSink describes an in-memory Sink used for testing.
+//
+// DEPRECATED: use "github.com/lyft/gostats/mock" instead.
 type MockSink struct {
 	Counters map[string]uint64
 	Timers   map[string]uint64
@@ -15,10 +15,10 @@ type MockSink struct {
 	gLock sync.Mutex
 }
 
-// DEPRECATED: use "github.com/lyft/gostats/mock" instead.
-//
 // NewMockSink returns a MockSink that flushes stats to in-memory maps. An
 // instance of MockSink is not safe for concurrent use.
+//
+// DEPRECATED: use "github.com/lyft/gostats/mock" instead.
 func NewMockSink() (m *MockSink) {
 	m = &MockSink{
 		Counters: make(map[string]uint64),

--- a/stat_handler_test.go
+++ b/stat_handler_test.go
@@ -8,12 +8,14 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/lyft/gostats/mock"
 )
 
 func TestHttpHandler_ServeHTTP(t *testing.T) {
 	t.Parallel()
 
-	sink := NewMockSink()
+	sink := mock.NewSink()
 	store := NewStore(sink, false)
 
 	h := NewStatHandler(
@@ -67,24 +69,7 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 
 	wg.Wait()
 
-	timer, ok := sink.Timers[requestTimer]
-	if !ok {
-		t.Errorf("wanted a %q timer, none found", requestTimer)
-	} else if timer != 2 {
-		t.Error("wanted 2, got", timer)
-	}
-
-	c, ok := sink.Counters["200"]
-	if !ok {
-		t.Error("wanted a '200' counter, none found")
-	} else if c != 1 {
-		t.Error("wanted 1, got", c)
-	}
-
-	c, ok = sink.Counters["404"]
-	if !ok {
-		t.Error("wanted a '404' counter, none found")
-	} else if c != 1 {
-		t.Error("wanted 1, got", c)
-	}
+	sink.AssertTimerCallCount(t, requestTimer, 2)
+	sink.AssertCounterEquals(t, "200", 1)
+	sink.AssertCounterEquals(t, "404", 1)
 }


### PR DESCRIPTION
A common error in test code is to use a racy Store or Sink implementation and the existing MockSink cannot be used in a thread-safe manner by consumers of this library.  This PR adds a thread-safe Sink implementation that can be used with the existing Store code.

Additionally, the Sink has helper methods to make testing easier.