### PR TITLE
Go 1.12 Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - "1.10"
   - "1.11"
+  - "1.12"
 
 before_install: mkdir -p $GOPATH/bin
 install:        make install

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-# the name of this package
-PKG := $(shell go list .)
+# Go source files
+SRCS := $(shell find . -type d -name 'vendor' -prune -o -name '*.go' -print)
 
 .PHONY: install
 install: glide #download dependencies (including test deps) for the package
@@ -11,25 +11,32 @@ update: glide #updates dependencies used by the package and installs them
 
 .PHONY: glide
 glide: # ensure the glide package tool is installed
-	which glide || (curl https://glide.sh/get | sh)
+	which glide || go get github.com/Masterminds/glide
 
 .PHONY: lint
 lint: #lints the package for common code smells
+	@for file in $(SRCS); do \
+		gofmt -d -s $${file}; \
+		if [ -n "$$(gofmt -d -s $${file})" ]; then \
+			exit 1; \
+		fi; \
+	done
 	which golint || go get -u golang.org/x/lint/golint
-	test -z "$(gofmt -d -s ./*.go)" || (gofmt -d -s ./*.go && exit 1)
-	golint -set_exit_status
-	go tool vet -all -shadow -shadowstrict *.go
+	which shadow || go get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
+	golint -set_exit_status $(shell go list ./...)
+	go vet -all ./...
+	go vet -vettool=$(which shadow) ./...
 
 .PHONY: test
 test: # runs all tests against the package with race detection and coverage percentage
-	go test -race -cover
+	go test -race -cover ./...
 
 .PHONY: quick
 quick: # runs all tests without coverage or the race detector
-	go test
+	go test ./...
 
 .PHONY: cover
 cover: # runs all tests against the package, generating a coverage report and opening it in the default browser
-	go test -race -covermode=atomic -coverprofile=cover.out
+	go test -race -covermode=atomic -coverprofile=cover.out ./...
 	go tool cover -html cover.out -o cover.html
-	open cover.html
+	which open && open cover.html


### PR DESCRIPTION
* Update travis to run tests with Go 1.12
* Remove use of the deprecated `go tool vet`
* Run tests/linters against the newish `mock` package

**Blocked on:** https://github.com/lyft/gostats/pull/69