### PR TITLE
tags: Aggressively inline tag serialization small tag sets

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -30,16 +30,59 @@ func serializeTags(name string, tags map[string]string) string {
 		}
 		panic("unreachable")
 	case 2:
-		var a, b tagPair
+		var t0, t1 tagPair
 		for k, v := range tags {
-			b = a
-			a = tagPair{k, replaceChars(v)}
+			t1 = t0
+			t0 = tagPair{k, replaceChars(v)}
 		}
-		if a.dimension > b.dimension {
-			a, b = b, a
+		if t0.dimension > t1.dimension {
+			t0, t1 = t1, t0
 		}
-		return name + prefix + a.dimension + sep + a.value +
-			prefix + b.dimension + sep + b.value
+		return name + prefix + t0.dimension + sep + t0.value +
+			prefix + t1.dimension + sep + t1.value
+	case 3:
+		var t0, t1, t2 tagPair
+		for k, v := range tags {
+			t2 = t1
+			t1 = t0
+			t0 = tagPair{k, replaceChars(v)}
+		}
+		if t1.dimension > t2.dimension {
+			t1, t2 = t2, t1
+		}
+		if t0.dimension > t2.dimension {
+			t0, t2 = t2, t0
+		}
+		if t0.dimension > t1.dimension {
+			t0, t1 = t1, t0
+		}
+		return name + prefix + t0.dimension + sep + t0.value +
+			prefix + t1.dimension + sep + t1.value +
+			prefix + t2.dimension + sep + t2.value
+	case 4:
+		var t0, t1, t2, t3 tagPair
+		for k, v := range tags {
+			t3 = t2
+			t2 = t1
+			t1 = t0
+			t0 = tagPair{k, replaceChars(v)}
+		}
+		if t0.dimension > t1.dimension {
+			t0, t1 = t1, t0
+		}
+		if t2.dimension > t3.dimension {
+			t2, t3 = t3, t2
+		}
+		if t0.dimension > t2.dimension {
+			t0, t2 = t2, t0
+		}
+		if t1.dimension > t2.dimension {
+			t1, t2 = t2, t1
+		}
+		return name + prefix + t0.dimension + sep + t0.value +
+			prefix + t1.dimension + sep + t1.value +
+			prefix + t2.dimension + sep + t2.value +
+			prefix + t3.dimension + sep + t3.value
 	default:
 		// n stores the length of the serialized name + tags
 		n := (len(prefix) + len(sep)) * len(tags)

--- a/tags.go
+++ b/tags.go
@@ -76,6 +76,9 @@ func serializeTags(name string, tags map[string]string) string {
 		if t0.dimension > t2.dimension {
 			t0, t2 = t2, t0
 		}
+		if t1.dimension > t3.dimension {
+			t1, t3 = t3, t1
+		}
 		if t1.dimension > t2.dimension {
 			t1, t2 = t2, t1
 		}

--- a/tags.go
+++ b/tags.go
@@ -20,7 +20,6 @@ func serializeTags(name string, tags map[string]string) string {
 	const prefix = ".__"
 	const sep = "="
 
-	// switch len(tags) {
 	switch len(tags) {
 	case 0:
 		return name

--- a/tags_test.go
+++ b/tags_test.go
@@ -96,21 +96,6 @@ func TestSerializeTagValuePeriod(t *testing.T) {
 	}
 }
 
-func BenchmarkSerializeTags(b *testing.B) {
-	const name = "prefix"
-	tags := map[string]string{
-		"tag1": "val1",
-		"tag2": "val2",
-		"tag3": "val3",
-		"tag4": "val4",
-		"tag5": "val5",
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		serializeTags(name, tags)
-	}
-}
-
 func benchmarkSerializeTags(b *testing.B, n int) {
 	const name = "prefix"
 	tags := make(map[string]string, n)

--- a/tags_test.go
+++ b/tags_test.go
@@ -111,52 +111,56 @@ func BenchmarkSerializeTags(b *testing.B) {
 	}
 }
 
-func BenchmarkSerializeTags_One(b *testing.B) {
+func benchmarkSerializeTags(b *testing.B, n int) {
 	const name = "prefix"
-	tags := map[string]string{
-		"tag1": "val1",
+	tags := make(map[string]string, n)
+	for i := 0; i < n; i++ {
+		k := fmt.Sprintf("key%d", i)
+		v := fmt.Sprintf("val%d", i)
+		tags[k] = v
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		serializeTags(name, tags)
 	}
+}
+
+func BenchmarkSerializeTags_One(b *testing.B) {
+	benchmarkSerializeTags(b, 1)
 }
 
 func BenchmarkSerializeTags_Two(b *testing.B) {
-	const name = "prefix"
-	tags := map[string]string{
-		"tag1": "val1",
-		"tag2": "val2",
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		serializeTags(name, tags)
-	}
+	benchmarkSerializeTags(b, 2)
 }
 
 func BenchmarkSerializeTags_Three(b *testing.B) {
-	const name = "prefix"
-	tags := map[string]string{
-		"tag1": "val1",
-		"tag2": "val2",
-		"tag3": "val3",
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		serializeTags(name, tags)
-	}
+	benchmarkSerializeTags(b, 3)
 }
 
 func BenchmarkSerializeTags_Four(b *testing.B) {
-	const name = "prefix"
-	tags := map[string]string{
-		"tag1": "val1",
-		"tag2": "val2",
-		"tag3": "val3",
-		"tag4": "val4",
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		serializeTags(name, tags)
-	}
+	benchmarkSerializeTags(b, 4)
+}
+
+func BenchmarkSerializeTags_Five(b *testing.B) {
+	benchmarkSerializeTags(b, 5)
+}
+
+func BenchmarkSerializeTags_Six(b *testing.B) {
+	benchmarkSerializeTags(b, 6)
+}
+
+func BenchmarkSerializeTags_Seven(b *testing.B) {
+	benchmarkSerializeTags(b, 7)
+}
+
+func BenchmarkSerializeTags_Eight(b *testing.B) {
+	benchmarkSerializeTags(b, 8)
+}
+
+func BenchmarkSerializeTags_Nine(b *testing.B) {
+	benchmarkSerializeTags(b, 9)
+}
+
+func BenchmarkSerializeTags_Ten(b *testing.B) {
+	benchmarkSerializeTags(b, 10)
 }

--- a/tags_test.go
+++ b/tags_test.go
@@ -110,42 +110,10 @@ func benchmarkSerializeTags(b *testing.B, n int) {
 	}
 }
 
-func BenchmarkSerializeTags_One(b *testing.B) {
-	benchmarkSerializeTags(b, 1)
-}
-
-func BenchmarkSerializeTags_Two(b *testing.B) {
-	benchmarkSerializeTags(b, 2)
-}
-
-func BenchmarkSerializeTags_Three(b *testing.B) {
-	benchmarkSerializeTags(b, 3)
-}
-
-func BenchmarkSerializeTags_Four(b *testing.B) {
-	benchmarkSerializeTags(b, 4)
-}
-
-func BenchmarkSerializeTags_Five(b *testing.B) {
-	benchmarkSerializeTags(b, 5)
-}
-
-func BenchmarkSerializeTags_Six(b *testing.B) {
-	benchmarkSerializeTags(b, 6)
-}
-
-func BenchmarkSerializeTags_Seven(b *testing.B) {
-	benchmarkSerializeTags(b, 7)
-}
-
-func BenchmarkSerializeTags_Eight(b *testing.B) {
-	benchmarkSerializeTags(b, 8)
-}
-
-func BenchmarkSerializeTags_Nine(b *testing.B) {
-	benchmarkSerializeTags(b, 9)
-}
-
-func BenchmarkSerializeTags_Ten(b *testing.B) {
-	benchmarkSerializeTags(b, 10)
+func BenchmarkSerializeTags(b *testing.B) {
+	for i := 1; i <= 10; i++ {
+		b.Run(fmt.Sprintf("%d", i), func(b *testing.B) {
+			benchmarkSerializeTags(b, i)
+		})
+	}
 }

--- a/tags_test.go
+++ b/tags_test.go
@@ -85,3 +85,30 @@ func BenchmarkSerializeTags_Two(b *testing.B) {
 		serializeTags(name, tags)
 	}
 }
+
+func BenchmarkSerializeTags_Three(b *testing.B) {
+	const name = "prefix"
+	tags := map[string]string{
+		"tag1": "val1",
+		"tag2": "val2",
+		"tag3": "val3",
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		serializeTags(name, tags)
+	}
+}
+
+func BenchmarkSerializeTags_Four(b *testing.B) {
+	const name = "prefix"
+	tags := map[string]string{
+		"tag1": "val1",
+		"tag2": "val2",
+		"tag3": "val3",
+		"tag4": "val4",
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		serializeTags(name, tags)
+	}
+}


### PR DESCRIPTION
Most tag sets are small.  This improves runtime by roughly 25% and reduces allocs by roughly 70% when using 4 or less tags.

Benchmark results:

```
benchmark                               old ns/op     new ns/op     delta
BenchmarkSerializeTags_Four-8           341           262           -23.17%

benchmark                               old allocs     new allocs     delta
BenchmarkSerializeTags_Four-8           3              1              -66.67%

benchmark                               old bytes     new bytes     delta
BenchmarkSerializeTags_Four-8           224           64            -71.43%
```