### PR TITLE
stats: recover expvar panic

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -526,12 +526,7 @@ func (s subScope) mergeTags(tags map[string]string) map[string]string {
 	return tags
 }
 
-// seenExpVars prevents duplicate names from being published
-// to expvars since doing so triggers a panic.
-var seenExpVars sync.Map
-
 func publishExpVar(name string, v expvar.Var) {
-	if _, found := seenExpVars.LoadOrStore(name, struct{}{}); !found {
-		expvar.Publish(name, v)
-	}
+	defer func() { recover() }()
+	expvar.Publish(name, v)
 }


### PR DESCRIPTION
TLDR: this should be removed but until then defer and recover the panic
instead of using a sync.Map.  Since there is a race with the later.