### PR TITLE
NewDefaultStore: don't export stats by default

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -194,7 +194,7 @@ func NewDefaultStore() Store {
 		newStore = NewStore(NewLoggingSink(), false)
 		go newStore.Start(time.NewTicker(10 * time.Second))
 	} else {
-		newStore = NewStore(NewTCPStatsdSink(), true)
+		newStore = NewStore(NewTCPStatsdSink(), false)
 		go newStore.Start(time.NewTicker(time.Duration(settings.FlushIntervalS) * time.Second))
 	}
 	return newStore


### PR DESCRIPTION
If export is true then stats are exported via the expvars package, which gostats uses incorrectly (it should only be used in init() functions) and as a result is slow (it resorts all stored variables whenever a new one is added).