### PR TITLE
Prevent the tcp sink from blocking

### DIFF
--- a/tcp_sink.go
+++ b/tcp_sink.go
@@ -184,13 +184,8 @@ func (s *tcpStatsdSink) run() {
 		select {
 		case <-t.C:
 			s.flush()
-		case buf, ok := <-s.outc: // Receive from the channel and check if the channel has been closed
-			if !ok {
-				logger.Warnf("Closing statsd client")
-				s.conn.Close()
-				return
-			}
-			lenbuf := len(buf.Bytes())
+		case buf := <-s.outc:
+			lenbuf := buf.Len()
 			_, err := buf.WriteTo(s.conn)
 			if len(s.outc) == 0 {
 				// We've at least tried to write all the data we have. Wake up anyone waiting on flush.

--- a/tcp_sink.go
+++ b/tcp_sink.go
@@ -76,7 +76,7 @@ func (s *tcpStatsdSink) Flush() {
 		return
 	}
 	s.mu.Lock()
-	for now.After(s.lastFlushTime) {
+	for len(s.outc) != 0 && now.After(s.lastFlushTime) {
 		s.flushCond.Wait()
 	}
 	s.mu.Unlock()


### PR DESCRIPTION
This PR fixes a bug with the `tcpStatsdSink` that would lead to `.Flush()` blocking indefinitely if there was nothing to flush.  It additionally, improves the reliability of the `tcpStatsdSink` by ensuring that establishing and writing to its `net.Conn` never blocks.

bb1cc197f143cb5f46892c20718c64e9ae421eed

    tcp sink: Add connect and write timeouts

    This will prevent establishing or writing to a net.Conn from hanging the
    program.

964db46b11c3d1cf0a8de011da679c639ef4b9af

    tcp sink: ensure Flush() exits

    Previosly, continuous writes could prevent calls to Flush() from
    exiting.  This commit changes Flush() to only flush buffers that
    are pending at the time Flush() is called.

a765536086bb81788b3d74ee0d851887b8b8f929

    tcp sink: remove close channel check

    The channel is never closed.

2c74015ca528263694d130b05b57d3abee92005b

    tcp sink: prevent flush from hanging when there is nothing to flush