### PR TITLE
tcp_sink: don't allow Flush() to block forever

### DIFF
--- a/tcp_sink.go
+++ b/tcp_sink.go
@@ -77,11 +77,9 @@ func (s *tcpStatsdSink) Flush() {
 	if s.flush() != nil {
 		return // nothing we can do
 	}
-	if len(s.outc) > 0 {
-		ch := make(chan struct{})
-		s.doFlush <- ch
-		<-ch
-	}
+	ch := make(chan struct{})
+	s.doFlush <- ch
+	<-ch
 }
 
 func (s *tcpStatsdSink) flush() error {


### PR DESCRIPTION
This fixes a bug in the `Flush()` logic introduced in https://github.com/lyft/gostats/pull/79 that can cause `Flush()` to hang if items are added the `tcpStatsdSink.outc` channel while in the flush loop ([discussion](https://github.com/lyft/gostats/pull/79/files#r347570672)).
