### PR TITLE
tcp_sink_test: add test to verify that Flush() does not hang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ go:
 
 before_install: mkdir -p $GOPATH/bin
 install:        make install
-script:         make lint test
+script:         make lint quick test

--- a/tcp_sink_test.go
+++ b/tcp_sink_test.go
@@ -416,7 +416,7 @@ func TestTCPStatsdSink_Flush(t *testing.T) {
 			case <-done:
 				return
 			default:
-				for i := 0; i < 100; i++ {
+				for i := 0; i < 1000; i++ {
 					sink.FlushCounter(name, 1)
 				}
 			}


### PR DESCRIPTION
This is to reproduce the bug introduced by https://github.com/lyft/gostats/pull/79 and verify the fix added by https://github.com/lyft/gostats/pull/84.

Note: tests will fail until the fix added by https://github.com/lyft/gostats/pull/84 is merged and this PR.