### PR TITLE
settings: remove envconfig

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,16 +1,14 @@
 hash: 5f6a20dfcbd0d3f8669061128596d7b554934928a05f38a7e8d385c9c78b82d8
-updated: 2017-08-28T01:16:37.227752883+02:00
+updated: 2020-02-05T16:49:48.973286-05:00
 imports:
-- name: github.com/kelseyhightower/envconfig
-  version: f611eb38b3875cc3bd991ca91c51d06446afa14c
 - name: github.com/sirupsen/logrus
-  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
+  version: 3e01752db0189b9157070a0e1668a620f9a85da2
 - name: golang.org/x/crypto
-  version: 81e90905daefcd6fd217b62423c0908922eadb30
+  version: c9f3fb736b729628ec1e9c1a6b4313e883f452f9
   subpackages:
   - ssh/terminal
 - name: golang.org/x/sys
-  version: d8f5ea21b9295e315e612b4bcf4bedea93454d4d
+  version: d101bd2416d505c0448a6ce8a282482678040a89
   subpackages:
   - unix
   - windows

--- a/settings.go
+++ b/settings.go
@@ -1,6 +1,21 @@
 package stats
 
-import "github.com/kelseyhightower/envconfig"
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+const (
+	// DefaultUseStatsd use statsd as a stats sink, default is false.
+	DefaultUseStatsd = false
+	// DefaultStatsdHost is the default address where statsd is running at.
+	DefaultStatsdHost = "localhost"
+	// DefaultStatsdPort is the default port where statsd is listening at.
+	DefaultStatsdPort = 8125
+	// DefaultFlushIntervalS is the default flushing interval in seconds.
+	DefaultFlushIntervalS = 5
+)
 
 // The Settings type is used to configure gostats. gostats uses environment
 // variables to setup its settings.
@@ -15,12 +30,67 @@ type Settings struct {
 	FlushIntervalS int `envconfig:"GOSTATS_FLUSH_INTERVAL_SECONDS" default:"5"`
 }
 
+// An envError is an error that occured parsing an environment variable
+type envError struct {
+	Key   string
+	Value string
+	Err   error
+}
+
+func (e *envError) Error() string {
+	return fmt.Sprintf("parsing environment variable: %q with value: %q: %s",
+		e.Key, e.Value, e.Err)
+}
+
+func envOr(key, def string) string {
+	if s := os.Getenv(key); s != "" {
+		return s
+	}
+	return def
+}
+
+func envInt(key string, def int) (int, error) {
+	s := os.Getenv(key)
+	if s == "" {
+		return def, nil
+	}
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		return def, &envError{Key: key, Value: s, Err: err}
+	}
+	return i, nil
+}
+
+func envBool(key string, def bool) (bool, error) {
+	s := os.Getenv(key)
+	if s == "" {
+		return def, nil
+	}
+	b, err := strconv.ParseBool(s)
+	if err != nil {
+		return def, &envError{Key: key, Value: s, Err: err}
+	}
+	return b, nil
+}
+
 // GetSettings returns the Settings gostats will run with.
 func GetSettings() Settings {
-	var s Settings
-	err := envconfig.Process("", &s)
+	useStatsd, err := envBool("USE_STATSD", DefaultUseStatsd)
 	if err != nil {
 		panic(err)
 	}
-	return s
+	statsdPort, err := envInt("STATSD_PORT", DefaultStatsdPort)
+	if err != nil {
+		panic(err)
+	}
+	flushIntervalS, err := envInt("GOSTATS_FLUSH_INTERVAL_SECONDS", DefaultFlushIntervalS)
+	if err != nil {
+		panic(err)
+	}
+	return Settings{
+		UseStatsd:      useStatsd,
+		StatsdHost:     envOr("STATSD_HOST", DefaultStatsdHost),
+		StatsdPort:     statsdPort,
+		FlushIntervalS: flushIntervalS,
+	}
 }

--- a/settings_test.go
+++ b/settings_test.go
@@ -1,0 +1,95 @@
+package stats
+
+import (
+	"os"
+	"testing"
+)
+
+func testSetenv(t *testing.T, pairs ...string) (reset func()) {
+	var fns []func()
+	for i := 0; i < len(pairs); i += 2 {
+		key := pairs[i+0]
+		val := pairs[i+1]
+
+		prev, exists := os.LookupEnv(key)
+		if err := os.Setenv(key, val); err != nil {
+			t.Fatalf("setting env key: %s: %s", key, err)
+		}
+		if exists {
+			fns = append(fns, func() { os.Setenv(key, prev) })
+		} else {
+			fns = append(fns, func() { os.Unsetenv(key) })
+		}
+	}
+	return func() {
+		for _, fn := range fns {
+			fn()
+		}
+	}
+}
+
+func TestSettingsDefault(t *testing.T) {
+	reset := testSetenv(t,
+		"USE_STATSD", "",
+		"STATSD_HOST", "",
+		"STATSD_PORT", "",
+		"GOSTATS_FLUSH_INTERVAL_SECONDS", "",
+	)
+	defer reset()
+	exp := Settings{
+		UseStatsd:      DefaultUseStatsd,
+		StatsdHost:     DefaultStatsdHost,
+		StatsdPort:     DefaultStatsdPort,
+		FlushIntervalS: DefaultFlushIntervalS,
+	}
+	settings := GetSettings()
+	if exp != settings {
+		t.Errorf("Default: want: %+v got: %+v", exp, settings)
+	}
+}
+
+func TestSettingsOverride(t *testing.T) {
+	reset := testSetenv(t,
+		"USE_STATSD", "true",
+		"STATSD_HOST", "10.0.0.1",
+		"STATSD_PORT", "1234",
+		"GOSTATS_FLUSH_INTERVAL_SECONDS", "3",
+	)
+	defer reset()
+	exp := Settings{
+		UseStatsd:      true,
+		StatsdHost:     "10.0.0.1",
+		StatsdPort:     1234,
+		FlushIntervalS: 3,
+	}
+	settings := GetSettings()
+	if exp != settings {
+		t.Errorf("Default: want: %+v got: %+v", exp, settings)
+	}
+}
+
+func TestSettingsErrors(t *testing.T) {
+	// STATSD_HOST doesn't error so we don't check it
+
+	tests := map[string]string{
+		"USE_STATSD":                     "FOO!",
+		"STATSD_PORT":                    "not-an-int",
+		"GOSTATS_FLUSH_INTERVAL_SECONDS": "true",
+	}
+	for key, val := range tests {
+		t.Run(key, func(t *testing.T) {
+			reset := testSetenv(t, key, val)
+			defer reset()
+			var panicked bool
+			func() {
+				defer func() {
+					panicked = recover() != nil
+				}()
+				GetSettings()
+			}()
+			if !panicked {
+				t.Errorf("Settings expected a panic for invalid value %s=%s", key, val)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I don't like envconfig and it's kinda overkill for parsing 4 things from
the env.

TODO: we really need to fix how GetSettings() is used since it makes
configuring gostats really annoying and really limits its use cases.