### PR TITLE
WIP: stats: add new *WithTag() methods for creating a new stat with one tag

### DIFF
--- a/stats_test.go
+++ b/stats_test.go
@@ -88,6 +88,17 @@ func BenchmarkStore_NewCounterWithTags(b *testing.B) {
 	}
 }
 
+func BenchmarkStore_NewCounterWithTag(b *testing.B) {
+	s := NewStore(nullSink{}, false)
+	t := time.NewTicker(time.Hour) // don't flush
+	defer t.Stop()
+	go s.Start(t)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.NewCounterWithTag("counter_name", "tag1", "val1")
+	}
+}
+
 func initBenchScope() (scope Scope, childTags map[string]string) {
 	s := NewStore(nullSink{}, false)
 

--- a/tags.go
+++ b/tags.go
@@ -16,6 +16,15 @@ func (t tagSet) Len() int           { return len(t) }
 func (t tagSet) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
 func (t tagSet) Less(i, j int) bool { return t[i].dimension < t[j].dimension }
 
+func serializeTag(name, key, value string) string {
+	const prefix = ".__"
+	const sep = "="
+	if key == "" || value == "" {
+		return name
+	}
+	return name + prefix + key + sep + replaceChars(value)
+}
+
 func serializeTags(name string, tags map[string]string) string {
 	const prefix = ".__"
 	const sep = "="

--- a/tags_test.go
+++ b/tags_test.go
@@ -166,6 +166,25 @@ func TestSerializeTagDiscardEmptyTagKeyValue(t *testing.T) {
 	}
 }
 
+func TestSerializeTag(t *testing.T) {
+	const (
+		prefix = ".__"
+		sep    = "="
+		name   = "x"
+	)
+	if s := serializeTag(name, "", "value"); s != name {
+		t.Errorf("serializeTag: got: %q want: %q", s, name)
+	}
+	if s := serializeTag(name, "key", ""); s != name {
+		t.Errorf("serializeTag: got: %q want: %q", s, name)
+	}
+
+	exp := name + prefix + "key" + sep + replaceChars("value")
+	if s := serializeTag(name, "key", "value"); s != exp {
+		t.Errorf("serializeTag: got: %q want: %q", s, exp)
+	}
+}
+
 func benchmarkSerializeTags(b *testing.B, n int) {
 	const name = "prefix"
 	tags := make(map[string]string, n)
@@ -177,6 +196,17 @@ func benchmarkSerializeTags(b *testing.B, n int) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		serializeTags(name, tags)
+	}
+}
+
+func BenchmarkSerializeTag(b *testing.B) {
+	const (
+		name  = "prefix"
+		key   = "key1"
+		value = "value1"
+	)
+	for i := 0; i < b.N; i++ {
+		serializeTag(name, key, value)
 	}
 }
 


### PR DESCRIPTION
**WIP:** still considering if this change is worth breaking current implementations of the `Scope` interface (or if a new interface should be returned instead).

Many invocations of *WithTags() add only a single tag, which is wasteful
as it requires allocating a new map. This commit adds the *WithTag()
convenience methods for creating a new Counter, Gauge or Timer with only
a single tag. This is about 3.5x faster.

```
BenchmarkStore_NewCounterWithTag/WithTag-12   14092364  85.7 ns/op  32 B/op   1 allocs/op
BenchmarkStore_NewCounterWithTag/Baseline-12  4078476   290 ns/op   368 B/op  3 allocs/op
```