### PR TITLE
tcp_sink: don't hang on flush if reconnecting

### DIFF
--- a/tcp_sink_test.go
+++ b/tcp_sink_test.go
@@ -2,13 +2,19 @@ package stats
 
 import (
 	"bufio"
+	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -478,6 +484,476 @@ func TestTCPStatsdSink_Flush(t *testing.T) {
 			// ok
 		case <-time.After(time.Second):
 			t.Fatal("Flush blocked")
+		}
+	})
+}
+
+// Test that drainFlushQueue() does not hang when there are continuous
+// flush requests.
+func TestTCPStatsdSink_DrainFlushQueue(t *testing.T) {
+	s := &tcpStatsdSink{
+		doFlush: make(chan chan struct{}, 8),
+	}
+
+	sent := new(int64)
+
+	// Saturate the flush channel
+
+	done := make(chan struct{})
+	defer close(done)
+
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go func() {
+			for {
+				select {
+				case s.doFlush <- make(chan struct{}):
+					atomic.AddInt64(sent, 1)
+				case <-done:
+					return
+				}
+			}
+		}()
+	}
+
+	// Wait for the flush channel to fill
+	for len(s.doFlush) < cap(s.doFlush) {
+		runtime.Gosched()
+	}
+
+	flushed := make(chan struct{})
+	go func() {
+		s.drainFlushQueue()
+		close(flushed)
+	}()
+
+	// We will flush up to cap(s.doFlush) * 8 items, so the max number
+	// of sends will be that plus the capacity of the buffer.
+	maxSends := cap(s.doFlush)*8 + cap(s.doFlush)
+
+	select {
+	case <-flushed:
+		n := int(atomic.LoadInt64(sent))
+		switch {
+		case n < cap(s.doFlush):
+			// This should be impossible since we fill the channel
+			// before calling drainFlushQueue().
+			t.Errorf("Sent less than %d items: %d", cap(s.doFlush), n)
+		case n > maxSends:
+			// This should be nearly impossible to get without inserting
+			// runtime.Gosched() into the flush/drain loop.
+			t.Errorf("Sent more than %d items: %d", maxSends, n)
+		}
+	case <-time.After(time.Second / 2):
+		// 500ms is really generous, it should return almost immediately.
+		t.Error("drainFlushQueue did not return in time")
+	}
+}
+
+type tcpTestSink struct {
+	ll    *net.TCPListener
+	addr  *net.TCPAddr
+	mu    sync.Mutex // buf lock
+	buf   bytes.Buffer
+	stats chan string
+	done  chan struct{} // closed when read loop exits
+}
+
+func newTCPTestSink(t testing.TB) *tcpTestSink {
+	l, err := net.ListenTCP("tcp", &net.TCPAddr{
+		IP:   net.IPv4(127, 0, 0, 1),
+		Port: 0,
+	})
+	if err != nil {
+		t.Fatal("ListenTCP:", err)
+	}
+	s := &tcpTestSink{
+		ll:    l,
+		addr:  l.Addr().(*net.TCPAddr),
+		stats: make(chan string, 64),
+		done:  make(chan struct{}),
+	}
+	go s.run(t)
+	return s
+}
+
+func (s *tcpTestSink) writeStat(line []byte) {
+	select {
+	case s.stats <- string(line):
+	default:
+	}
+	s.mu.Lock()
+	s.buf.Write(line)
+	s.mu.Unlock()
+}
+
+func (s *tcpTestSink) run(t testing.TB) {
+	defer close(s.done)
+	buf := bufio.NewReader(nil)
+	for {
+		conn, err := s.ll.AcceptTCP()
+		if err != nil {
+			// Log errors other than poll.ErrNetClosing, which is an
+			// internal error so we have to match against it's string.
+			if !strings.Contains(err.Error(), "use of closed network connection") {
+				t.Logf("Error: accept: %v", err)
+			}
+			return
+		}
+		// read stats line by line
+		buf.Reset(conn)
+		for {
+			b, e := buf.ReadBytes('\n')
+			if len(b) > 0 {
+				s.writeStat(b)
+			}
+			if e != nil {
+				if e != io.EOF {
+					err = e
+				}
+				break
+			}
+		}
+		if buf.Buffered() != 0 {
+			buf.WriteTo(&s.buf)
+		}
+		if err != nil {
+			t.Errorf("Error: reading stats: %v", err)
+		}
+	}
+}
+
+func (s *tcpTestSink) Restart(t testing.TB, resetBuffer bool) {
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	l, err := net.ListenTCP(s.addr.Network(), s.addr)
+	if err != nil {
+		t.Fatalf("restarting connection: %v", err)
+	}
+	if resetBuffer {
+		s.buf.Reset()
+	}
+	*s = tcpTestSink{
+		ll:    l,
+		addr:  s.addr,
+		buf:   s.buf,
+		stats: make(chan string, 64),
+		done:  make(chan struct{}),
+	}
+	go s.run(t)
+}
+
+func (s *tcpTestSink) Close() error {
+	select {
+	case <-s.done:
+		return nil // closed
+	default:
+		return s.ll.Close()
+	}
+}
+
+func (s *tcpTestSink) WaitForStat(t testing.TB, timeout time.Duration) string {
+	t.Helper()
+	if timeout <= 0 {
+		timeout = defaultRetryInterval * 2
+	}
+	to := time.NewTimer(timeout)
+	defer to.Stop()
+	select {
+	case s := <-s.stats:
+		return s
+	case <-to.C:
+		t.Fatalf("timeout waiting to receive stat: %s", timeout)
+	}
+	return ""
+}
+
+func (s *tcpTestSink) Stats() <-chan string {
+	return s.stats
+}
+
+func (s *tcpTestSink) Bytes() []byte {
+	s.mu.Lock()
+	b := append([]byte(nil), s.buf.Bytes()...)
+	s.mu.Unlock()
+	return b
+}
+
+func (s *tcpTestSink) String() string {
+	s.mu.Lock()
+	str := s.buf.String()
+	s.mu.Unlock()
+	return str
+}
+
+func (s *tcpTestSink) Address() *net.TCPAddr {
+	return s.addr
+}
+
+func mergeEnv(extra ...string) []string {
+	var prefixes []string
+	for _, s := range extra {
+		n := strings.IndexByte(s, '=')
+		prefixes = append(prefixes, s[:n+1])
+	}
+	ignore := func(s string) bool {
+		for _, pfx := range prefixes {
+			if strings.HasPrefix(s, pfx) {
+				return true
+			}
+		}
+		return false
+	}
+
+	env := os.Environ()
+	a := env[:0]
+	for _, s := range env {
+		if !ignore(s) {
+			a = append(a, s)
+		}
+	}
+	return append(a, extra...)
+}
+
+// CommandEnv returns the environment variables for an *exec.Cmd to use
+// with this test sink.
+func (s *tcpTestSink) CommandEnv() []string {
+	return mergeEnv(
+		fmt.Sprintf("STATSD_PORT=%d", s.Address().Port),
+		fmt.Sprintf("STATSD_HOST=%s", s.Address().IP.String()),
+		"GOSTATS_FLUSH_INTERVAL_SECONDS=1",
+	)
+}
+
+func discardLogger() *logger.Logger {
+	log := logger.New()
+	log.Out = ioutil.Discard
+	return log
+}
+
+func TestTCPStatsdSink(t *testing.T) {
+	setup := func(t *testing.T, stop bool) (*tcpTestSink, *tcpStatsdSink) {
+		ts := newTCPTestSink(t)
+
+		if stop {
+			if err := ts.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		sink := NewTCPStatsdSink(
+			WithLogger(discardLogger()),
+			WithStatsdHost(ts.Address().IP.String()),
+			WithStatsdPort(ts.Address().Port),
+		).(*tcpStatsdSink)
+
+		return ts, sink
+	}
+
+	t.Run("StatTypes", func(t *testing.T) {
+		var expected = [...]string{
+			"counter:1|c\n",
+			"gauge:1|g\n",
+			"timer_int:1|ms\n",
+			"timer_float:1.230000|ms\n",
+		}
+
+		ts, sink := setup(t, false)
+		defer ts.Close()
+
+		sink.FlushCounter("counter", 1)
+		sink.FlushGauge("gauge", 1)
+		sink.FlushTimer("timer_int", 1)
+		sink.FlushTimer("timer_float", 1.23)
+		sink.Flush()
+
+		for _, exp := range expected {
+			stat := ts.WaitForStat(t, time.Millisecond*50)
+			if stat != exp {
+				t.Errorf("stats got: %q want: %q", stat, exp)
+			}
+		}
+
+		// make sure there aren't any extra stats we're missing
+		exp := strings.Join(expected[:], "")
+		buf := ts.String()
+		if buf != exp {
+			t.Errorf("stats buffer\ngot:\n%q\nwant:\n%q\n", buf, exp)
+		}
+	})
+
+	// Make sure that stats are immediately flushed so that stats from fast
+	// exiting programs are not lost.
+	t.Run("ImmediateFlush", func(t *testing.T) {
+		const expected = "counter:1|c\n"
+
+		ts, sink := setup(t, false)
+		defer ts.Close()
+
+		sink.FlushCounter("counter", 1)
+		sink.Flush()
+
+		stat := ts.WaitForStat(t, time.Millisecond*50)
+		if stat != expected {
+			t.Errorf("stats got: %q want: %q", stat, expected)
+		}
+	})
+
+	// Test that we can successfully reconnect and flush a stat.
+	t.Run("Reconnect", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("Skipping: short test")
+		}
+		t.Parallel()
+
+		const expected = "counter:1|c\n"
+
+		ts, sink := setup(t, true)
+		defer ts.Close()
+
+		sink.FlushCounter("counter", 1)
+
+		flushed := make(chan struct{})
+		go func() {
+			sink.Flush()
+			close(flushed)
+		}()
+
+		time.Sleep(time.Millisecond * 100)
+		ts.Restart(t, true)
+
+		stat := ts.WaitForStat(t, defaultRetryInterval*2)
+		if stat != expected {
+			t.Errorf("stats got: %q want: %q", stat, expected)
+		}
+
+		// Make sure our flush call returned
+		select {
+		case <-flushed:
+		default:
+			t.Error("Flush() did not return")
+		}
+	})
+
+	// Test that when reconnecting fails, calls the Flush() do not block
+	// indefinitely.
+	t.Run("ReconnectFailure", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("Skipping: short test")
+		}
+		t.Parallel()
+
+		ts, sink := setup(t, true)
+		defer ts.Close()
+
+		sink.FlushCounter("counter", 1)
+
+		const N = 16
+		flushCount := new(int64)
+		flushed := make(chan struct{})
+		go func() {
+			wg := new(sync.WaitGroup)
+			wg.Add(N)
+			for i := 0; i < N; i++ {
+				go func() {
+					sink.Flush()
+					atomic.AddInt64(flushCount, 1)
+					wg.Done()
+				}()
+			}
+			wg.Wait()
+			close(flushed)
+		}()
+
+		// Make sure our flush call returned
+		select {
+		case <-flushed:
+			// Ok
+		case <-time.After(defaultRetryInterval * 2):
+			t.Fatalf("Only %d of %d Flush() calls succeeded",
+				atomic.LoadInt64(flushCount), N)
+		}
+	})
+}
+
+func buildBinary(t testing.TB, path string) (string, func()) {
+	var binaryName string
+	if strings.HasSuffix(path, ".go") {
+		// foo/bar/main.go => bar
+		binaryName = filepath.Base(filepath.Dir(path))
+	} else {
+		filepath.Base(path)
+	}
+
+	tmpdir, err := ioutil.TempDir("", "gostats-")
+	if err != nil {
+		t.Fatalf("creating tempdir: %v", err)
+	}
+	output := filepath.Join(tmpdir, binaryName)
+
+	out, err := exec.Command("go", "build", "-o", output, path).CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to build %s: %s\n### output:\n%s\n###\n",
+			path, err, strings.TrimSpace(string(out)))
+	}
+
+	cleanup := func() {
+		os.RemoveAll(tmpdir)
+	}
+	return output, cleanup
+}
+
+func TestTCPStatsdSink_Integration(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fastExitExe, deleteBinary := buildBinary(t, "testdata/fast_exit/fast_exit.go")
+	defer deleteBinary()
+
+	// Test the stats of a fast exiting program are captured.
+	t.Run("FastExit", func(t *testing.T) {
+		ts := newTCPTestSink(t)
+		defer ts.Close()
+
+		cmd := exec.CommandContext(ctx, fastExitExe)
+		cmd.Env = ts.CommandEnv()
+
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("Running command: %s\n### output:\n%s\n###\n",
+				fastExitExe, strings.TrimSpace(string(out)))
+		}
+
+		stats := ts.String()
+		const expected = "test.fast.exit.counter:1|c\n"
+		if stats != expected {
+			t.Errorf("stats: got: %q want: %q", stats, expected)
+		}
+	})
+
+	// Test that Flush() does not hang if the TCP sink is in a reconnect loop
+	t.Run("Reconnect", func(t *testing.T) {
+		ts := newTCPTestSink(t)
+		defer ts.Close()
+
+		cmd := exec.CommandContext(ctx, fastExitExe)
+		cmd.Env = ts.CommandEnv()
+
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+		errCh := make(chan error, 1)
+		go func() { errCh <- cmd.Wait() }()
+
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Fatal(err)
+			}
+		case <-time.After(defaultRetryInterval * 2):
+			t.Fatal("Timed out waiting for command to exit")
 		}
 	})
 }

--- a/tcp_sink_test.go
+++ b/tcp_sink_test.go
@@ -824,7 +824,7 @@ func TestTCPStatsdSink(t *testing.T) {
 
 		stat := ts.WaitForStat(t, defaultRetryInterval*2)
 		if stat != expected {
-			t.Errorf("stats got: %q want: %q", stat, expected)
+			t.Fatalf("stats got: %q want: %q", stat, expected)
 		}
 
 		// Make sure our flush call returned

--- a/tcp_sink_test.go
+++ b/tcp_sink_test.go
@@ -628,6 +628,12 @@ func (s *tcpTestSink) Restart(t testing.TB, resetBuffer bool) {
 			t.Fatal(err)
 		}
 	}
+	select {
+	case <-s.done:
+		// Ok
+	case <-time.After(time.Second * 3):
+		t.Fatal("timeout waiting for run loop to exit")
+	}
 	l, err := net.ListenTCP(s.addr.Network(), s.addr)
 	if err != nil {
 		t.Fatalf("restarting connection: %v", err)

--- a/testdata/fast_exit/.gitignore
+++ b/testdata/fast_exit/.gitignore
@@ -1,0 +1,2 @@
+fast_exit
+*.exe

--- a/testdata/fast_exit/fast_exit.go
+++ b/testdata/fast_exit/fast_exit.go
@@ -1,0 +1,11 @@
+package main
+
+import stats "github.com/lyft/gostats"
+
+// Test that the stats of a fast exiting program (such as one that immediately
+// errors on startup) can send stats.
+func main() {
+	store := stats.NewDefaultStore()
+	store.Scope("test.fast.exit").NewCounter("counter").Inc()
+	store.Flush()
+}


### PR DESCRIPTION
This fixes a bug where the TCP Sink would hang indefinitely on Flush()
if it was unable to reconnect.

It also adds the SinkOption interface for configuring the TCP Sink,
previously could only be done via environment variables (it still
defaults to using env vars). This changes the function signature of
NewTCPStatsdSink(), but the change should not be breaking since the new
"opts" argument is variadic.

This also significantly increases the code coverage of the TCP Sink
tests.