### PR TITLE
Add setting for disabling logging sink

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -34,7 +34,8 @@ type Settings struct {
 	StatsdPort int `envconfig:"STATSD_PORT" default:"8125"`
 	// Flushing interval.
 	FlushIntervalS int `envconfig:"GOSTATS_FLUSH_INTERVAL_SECONDS" default:"5"`
-	// Whether a LoggingSink should be used is Statsd is not enabled.
+	// Disable the LoggingSink when USE_STATSD is false and use the NullSink instead.
+	// This will cause all stats to be silently dropped.
 	LoggingSinkDisabled bool `envconfig:"GOSTATS_LOGGING_SINK_DISABLED" default:"false"`
 }
 

--- a/settings.go
+++ b/settings.go
@@ -17,6 +17,8 @@ const (
 	DefaultStatsdPort = 8125
 	// DefaultFlushIntervalS is the default flushing interval in seconds.
 	DefaultFlushIntervalS = 5
+	// DefaultLoggingSinkEnabled is the default behavior of logging sink enablement, default is false.
+	DefaultLoggingSinkEnabled = false
 )
 
 // The Settings type is used to configure gostats. gostats uses environment
@@ -32,6 +34,8 @@ type Settings struct {
 	StatsdPort int `envconfig:"STATSD_PORT" default:"8125"`
 	// Flushing interval.
 	FlushIntervalS int `envconfig:"GOSTATS_FLUSH_INTERVAL_SECONDS" default:"5"`
+	// Whether a LoggingSink should be used is Statsd is not enabled.
+	LoggingSinkEnabled bool `envconfig:"GOSTATS_LOGGING_SINK_ENABLED" default:"false"`
 }
 
 // An envError is an error that occured parsing an environment variable
@@ -91,11 +95,16 @@ func GetSettings() Settings {
 	if err != nil {
 		panic(err)
 	}
+	loggingSinkEnabled, err := envBool("GOSTATS_LOGGING_SINK_ENABLED", DefaultLoggingSinkEnabled)
+	if err != nil {
+		panic(err)
+	}
 	return Settings{
-		UseStatsd:      useStatsd,
-		StatsdHost:     envOr("STATSD_HOST", DefaultStatsdHost),
-		StatsdProtocol: envOr("STATSD_PROTOCOL", DefaultStatsdProtocol),
-		StatsdPort:     statsdPort,
-		FlushIntervalS: flushIntervalS,
+		UseStatsd:          useStatsd,
+		StatsdHost:         envOr("STATSD_HOST", DefaultStatsdHost),
+		StatsdProtocol:     envOr("STATSD_PROTOCOL", DefaultStatsdProtocol),
+		StatsdPort:         statsdPort,
+		FlushIntervalS:     flushIntervalS,
+		LoggingSinkEnabled: loggingSinkEnabled,
 	}
 }

--- a/settings.go
+++ b/settings.go
@@ -17,8 +17,8 @@ const (
 	DefaultStatsdPort = 8125
 	// DefaultFlushIntervalS is the default flushing interval in seconds.
 	DefaultFlushIntervalS = 5
-	// DefaultLoggingSinkEnabled is the default behavior of logging sink enablement, default is false.
-	DefaultLoggingSinkEnabled = false
+	// DefaultLoggingSinkDisabled is the default behavior of logging sink suppression, default is false.
+	DefaultLoggingSinkDisabled = false
 )
 
 // The Settings type is used to configure gostats. gostats uses environment
@@ -35,7 +35,7 @@ type Settings struct {
 	// Flushing interval.
 	FlushIntervalS int `envconfig:"GOSTATS_FLUSH_INTERVAL_SECONDS" default:"5"`
 	// Whether a LoggingSink should be used is Statsd is not enabled.
-	LoggingSinkEnabled bool `envconfig:"GOSTATS_LOGGING_SINK_ENABLED" default:"false"`
+	LoggingSinkDisabled bool `envconfig:"GOSTATS_LOGGING_SINK_DISABLED" default:"false"`
 }
 
 // An envError is an error that occured parsing an environment variable
@@ -95,16 +95,16 @@ func GetSettings() Settings {
 	if err != nil {
 		panic(err)
 	}
-	loggingSinkEnabled, err := envBool("GOSTATS_LOGGING_SINK_ENABLED", DefaultLoggingSinkEnabled)
+	loggingSinkDisabled, err := envBool("GOSTATS_LOGGING_SINK_DISABLED", DefaultLoggingSinkDisabled)
 	if err != nil {
 		panic(err)
 	}
 	return Settings{
-		UseStatsd:          useStatsd,
-		StatsdHost:         envOr("STATSD_HOST", DefaultStatsdHost),
-		StatsdProtocol:     envOr("STATSD_PROTOCOL", DefaultStatsdProtocol),
-		StatsdPort:         statsdPort,
-		FlushIntervalS:     flushIntervalS,
-		LoggingSinkEnabled: loggingSinkEnabled,
+		UseStatsd:           useStatsd,
+		StatsdHost:          envOr("STATSD_HOST", DefaultStatsdHost),
+		StatsdProtocol:      envOr("STATSD_PROTOCOL", DefaultStatsdProtocol),
+		StatsdPort:          statsdPort,
+		FlushIntervalS:      flushIntervalS,
+		LoggingSinkDisabled: loggingSinkDisabled,
 	}
 }

--- a/settings_test.go
+++ b/settings_test.go
@@ -44,6 +44,7 @@ func TestSettingsCompat(t *testing.T) {
 		"STATSD_PROTOCOL", "",
 		"STATSD_PORT", "",
 		"GOSTATS_FLUSH_INTERVAL_SECONDS", "",
+		"GOSTATS_LOGGING_SINK_ENABLED", "",
 	)
 	defer reset()
 
@@ -65,14 +66,16 @@ func TestSettingsDefault(t *testing.T) {
 		"STATSD_PROTOCOL", "",
 		"STATSD_PORT", "",
 		"GOSTATS_FLUSH_INTERVAL_SECONDS", "",
+		"GOSTATS_LOGGING_SINK_ENABLED", "",
 	)
 	defer reset()
 	exp := Settings{
-		UseStatsd:      DefaultUseStatsd,
-		StatsdHost:     DefaultStatsdHost,
-		StatsdProtocol: DefaultStatsdProtocol,
-		StatsdPort:     DefaultStatsdPort,
-		FlushIntervalS: DefaultFlushIntervalS,
+		UseStatsd:          DefaultUseStatsd,
+		StatsdHost:         DefaultStatsdHost,
+		StatsdProtocol:     DefaultStatsdProtocol,
+		StatsdPort:         DefaultStatsdPort,
+		FlushIntervalS:     DefaultFlushIntervalS,
+		LoggingSinkEnabled: DefaultLoggingSinkEnabled,
 	}
 	settings := GetSettings()
 	if exp != settings {
@@ -87,14 +90,16 @@ func TestSettingsOverride(t *testing.T) {
 		"STATSD_PROTOCOL", "udp",
 		"STATSD_PORT", "1234",
 		"GOSTATS_FLUSH_INTERVAL_SECONDS", "3",
+		"GOSTATS_LOGGING_SINK_ENABLED", "true",
 	)
 	defer reset()
 	exp := Settings{
-		UseStatsd:      true,
-		StatsdHost:     "10.0.0.1",
-		StatsdProtocol: "udp",
-		StatsdPort:     1234,
-		FlushIntervalS: 3,
+		UseStatsd:          true,
+		StatsdHost:         "10.0.0.1",
+		StatsdProtocol:     "udp",
+		StatsdPort:         1234,
+		FlushIntervalS:     3,
+		LoggingSinkEnabled: true,
 	}
 	settings := GetSettings()
 	if exp != settings {
@@ -109,6 +114,7 @@ func TestSettingsErrors(t *testing.T) {
 		"USE_STATSD":                     "FOO!",
 		"STATSD_PORT":                    "not-an-int",
 		"GOSTATS_FLUSH_INTERVAL_SECONDS": "true",
+		"GOSTATS_LOGGING_SINK_ENABLED":   "1337",
 	}
 	for key, val := range tests {
 		t.Run(key, func(t *testing.T) {

--- a/settings_test.go
+++ b/settings_test.go
@@ -44,7 +44,7 @@ func TestSettingsCompat(t *testing.T) {
 		"STATSD_PROTOCOL", "",
 		"STATSD_PORT", "",
 		"GOSTATS_FLUSH_INTERVAL_SECONDS", "",
-		"GOSTATS_LOGGING_SINK_ENABLED", "",
+		"GOSTATS_LOGGING_SINK_DISABLED", "",
 	)
 	defer reset()
 
@@ -66,16 +66,16 @@ func TestSettingsDefault(t *testing.T) {
 		"STATSD_PROTOCOL", "",
 		"STATSD_PORT", "",
 		"GOSTATS_FLUSH_INTERVAL_SECONDS", "",
-		"GOSTATS_LOGGING_SINK_ENABLED", "",
+		"GOSTATS_LOGGING_SINK_DISABLED", "",
 	)
 	defer reset()
 	exp := Settings{
-		UseStatsd:          DefaultUseStatsd,
-		StatsdHost:         DefaultStatsdHost,
-		StatsdProtocol:     DefaultStatsdProtocol,
-		StatsdPort:         DefaultStatsdPort,
-		FlushIntervalS:     DefaultFlushIntervalS,
-		LoggingSinkEnabled: DefaultLoggingSinkEnabled,
+		UseStatsd:           DefaultUseStatsd,
+		StatsdHost:          DefaultStatsdHost,
+		StatsdProtocol:      DefaultStatsdProtocol,
+		StatsdPort:          DefaultStatsdPort,
+		FlushIntervalS:      DefaultFlushIntervalS,
+		LoggingSinkDisabled: DefaultLoggingSinkDisabled,
 	}
 	settings := GetSettings()
 	if exp != settings {
@@ -90,16 +90,16 @@ func TestSettingsOverride(t *testing.T) {
 		"STATSD_PROTOCOL", "udp",
 		"STATSD_PORT", "1234",
 		"GOSTATS_FLUSH_INTERVAL_SECONDS", "3",
-		"GOSTATS_LOGGING_SINK_ENABLED", "true",
+		"GOSTATS_LOGGING_SINK_DISABLED", "true",
 	)
 	defer reset()
 	exp := Settings{
-		UseStatsd:          true,
-		StatsdHost:         "10.0.0.1",
-		StatsdProtocol:     "udp",
-		StatsdPort:         1234,
-		FlushIntervalS:     3,
-		LoggingSinkEnabled: true,
+		UseStatsd:           true,
+		StatsdHost:          "10.0.0.1",
+		StatsdProtocol:      "udp",
+		StatsdPort:          1234,
+		FlushIntervalS:      3,
+		LoggingSinkDisabled: true,
 	}
 	settings := GetSettings()
 	if exp != settings {
@@ -114,7 +114,7 @@ func TestSettingsErrors(t *testing.T) {
 		"USE_STATSD":                     "FOO!",
 		"STATSD_PORT":                    "not-an-int",
 		"GOSTATS_FLUSH_INTERVAL_SECONDS": "true",
-		"GOSTATS_LOGGING_SINK_ENABLED":   "1337",
+		"GOSTATS_LOGGING_SINK_DISABLED":  "1337",
 	}
 	for key, val := range tests {
 		t.Run(key, func(t *testing.T) {

--- a/stats.go
+++ b/stats.go
@@ -188,7 +188,11 @@ func NewDefaultStore() Store {
 	settings := GetSettings()
 	if !settings.UseStatsd {
 		logger.Warn("statsd is not in use")
-		newStore = NewStore(NewLoggingSink(), false)
+		if settings.LoggingSinkEnabled {
+			newStore = NewStore(NewLoggingSink(), false)
+		} else {
+			newStore = NewStore(NewNullSink(), false)
+		}
 		go newStore.Start(time.NewTicker(10 * time.Second))
 	} else {
 		newStore = NewStore(NewTCPStatsdSink(), false)

--- a/stats.go
+++ b/stats.go
@@ -188,10 +188,10 @@ func NewDefaultStore() Store {
 	settings := GetSettings()
 	if !settings.UseStatsd {
 		logger.Warn("statsd is not in use")
-		if settings.LoggingSinkEnabled {
-			newStore = NewStore(NewLoggingSink(), false)
-		} else {
+		if settings.LoggingSinkDisabled {
 			newStore = NewStore(NewNullSink(), false)
+		} else {
+			newStore = NewStore(NewLoggingSink(), false)
 		}
 		go newStore.Start(time.NewTicker(10 * time.Second))
 	} else {


### PR DESCRIPTION
As mentioned on slack: https://lyft.slack.com/archives/C0KLXB3KN/p1585349956028300

Our service emits many stats on startup, in dev we log at debug level
for easier development. The use of the logging sink and debug logs
results in a huge slowdown to our development startup times.

This PR adds a setting to disable debug logging when statsd is not
enabled.