### PR TITLE
Add UDP as a sink protocol

### DIFF
--- a/net_util_test.go
+++ b/net_util_test.go
@@ -1,0 +1,325 @@
+package stats
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type TestConn interface {
+	Close() (err error)
+	Address() net.Addr
+	Reconnect(t testing.TB, s *netTestSink)
+	Run(t testing.TB)
+}
+
+type udpConn struct {
+	ll        *net.UDPConn
+	addr      *net.UDPAddr
+	writeStat func(line []byte)
+	done      chan struct{}
+}
+
+func NewUDPConn(t testing.TB, s *netTestSink) TestConn {
+	l, err := net.ListenUDP("udp", &net.UDPAddr{
+		IP:   net.IPv4(127, 0, 0, 1),
+		Port: 0,
+	})
+	if err != nil {
+		t.Fatal("ListenUDP:", err)
+	}
+	c := &udpConn{
+		ll:        l,
+		addr:      l.LocalAddr().(*net.UDPAddr),
+		writeStat: s.writeStat,
+		done:      s.done,
+	}
+	go c.Run(t)
+	return c
+}
+
+func (c *udpConn) Address() net.Addr {
+	return c.ll.LocalAddr()
+}
+
+func (c *udpConn) Close() (err error) {
+	return c.ll.Close()
+}
+
+func (c *udpConn) Reconnect(t testing.TB, s *netTestSink) {
+	l, err := net.ListenUDP(c.addr.Network(), c.addr)
+	if err != nil {
+		t.Fatalf("restarting connection: %v", err)
+	}
+	c.ll = l
+	c.writeStat = s.writeStat
+	c.done = s.done
+	go c.Run(t)
+}
+
+func (c *udpConn) Run(t testing.TB) {
+	defer close(c.done)
+	buf := bufio.NewReader(c.ll)
+	var err error
+	for {
+		b, e := buf.ReadBytes('\n')
+		if len(b) > 0 {
+			c.writeStat(b)
+		}
+		if e != nil {
+			if e != io.EOF {
+				err = e
+			}
+			break
+		}
+	}
+	if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+		t.Logf("Error: reading stats: %v", err)
+	}
+}
+
+type tcpConn struct {
+	ll        *net.TCPListener
+	addr      *net.TCPAddr
+	writeStat func(line []byte)
+	done      chan struct{}
+}
+
+func NewTCPConn(t testing.TB, s *netTestSink) TestConn {
+	l, err := net.ListenTCP("tcp", &net.TCPAddr{
+		IP:   net.IPv4(127, 0, 0, 1),
+		Port: 0,
+	})
+	if err != nil {
+		t.Fatal("ListenTCP:", err)
+	}
+	c := &tcpConn{
+		ll:        l,
+		addr:      l.Addr().(*net.TCPAddr),
+		writeStat: s.writeStat,
+		done:      s.done,
+	}
+	go c.Run(t)
+	return c
+}
+
+func (c *tcpConn) Address() net.Addr {
+	return c.ll.Addr()
+}
+
+func (c *tcpConn) Close() (err error) {
+	return c.ll.Close()
+}
+
+func (c *tcpConn) Reconnect(t testing.TB, s *netTestSink) {
+	l, err := net.ListenTCP(c.addr.Network(), c.addr)
+	if err != nil {
+		t.Fatalf("restarting connection: %v", err)
+	}
+	c.ll = l
+	c.writeStat = s.writeStat
+	c.done = s.done
+	go c.Run(t)
+}
+
+func (c *tcpConn) Run(t testing.TB) {
+	defer close(c.done)
+	buf := bufio.NewReader(nil)
+	for {
+		conn, err := c.ll.AcceptTCP()
+		if err != nil {
+			// Log errors other than poll.ErrNetClosing, which is an
+			// internal error so we have to match against it's string.
+			if !strings.Contains(err.Error(), "use of closed network connection") {
+				t.Logf("Error: accept: %v", err)
+			}
+			return
+		}
+		// read stats line by line
+		buf.Reset(conn)
+		for {
+			b, e := buf.ReadBytes('\n')
+			if len(b) > 0 {
+				c.writeStat(b)
+			}
+			if e != nil {
+				if e != io.EOF {
+					err = e
+				}
+				break
+			}
+		}
+		if err != nil {
+			t.Errorf("Error: reading stats: %v", err)
+		}
+	}
+}
+
+type netTestSink struct {
+	conn     TestConn
+	mu       sync.Mutex // buf lock
+	buf      bytes.Buffer
+	stats    chan string
+	done     chan struct{} // closed when read loop exits
+	protocol string
+}
+
+func newNetTestSink(t testing.TB, protocol string) *netTestSink {
+	s := &netTestSink{
+		stats:    make(chan string, 64),
+		done:     make(chan struct{}),
+		protocol: protocol,
+	}
+	switch protocol {
+	case "udp":
+		s.conn = NewUDPConn(t, s)
+	case "tcp":
+		s.conn = NewTCPConn(t, s)
+	default:
+		t.Fatalf("invalid network protocol: %q", protocol)
+	}
+	return s
+}
+
+func (s *netTestSink) writeStat(line []byte) {
+	select {
+	case s.stats <- string(line):
+	default:
+	}
+	s.mu.Lock()
+	s.buf.Write(line)
+	s.mu.Unlock()
+}
+
+func (s *netTestSink) Restart(t testing.TB, resetBuffer bool) {
+	if err := s.Close(); err != nil {
+		if !strings.Contains(err.Error(), "use of closed network connection") {
+			t.Fatal(err)
+		}
+	}
+	select {
+	case <-s.done:
+		// Ok
+	case <-time.After(time.Second * 3):
+		t.Fatal("timeout waiting for run loop to exit")
+	}
+
+	if resetBuffer {
+		s.buf.Reset()
+	}
+	s.stats = make(chan string, 64)
+	s.done = make(chan struct{})
+	s.conn.Reconnect(t, s)
+}
+
+func (s *netTestSink) WaitForStat(t testing.TB, timeout time.Duration) string {
+	t.Helper()
+	if timeout <= 0 {
+		timeout = defaultRetryInterval * 2
+	}
+	to := time.NewTimer(timeout)
+	defer to.Stop()
+	select {
+	case s := <-s.stats:
+		return s
+	case <-to.C:
+		t.Fatalf("timeout waiting to receive stat: %s", timeout)
+	}
+	return ""
+}
+
+func (s *netTestSink) Close() error {
+	select {
+	case <-s.done:
+		return nil // closed
+	default:
+		return s.conn.Close() // WARN
+		// return s.ll.Close() // WARN
+	}
+}
+
+func (s *netTestSink) Stats() <-chan string {
+	return s.stats
+}
+
+func (s *netTestSink) Bytes() []byte {
+	s.mu.Lock()
+	b := append([]byte(nil), s.buf.Bytes()...)
+	s.mu.Unlock()
+	return b
+}
+
+func (s *netTestSink) String() string {
+	s.mu.Lock()
+	str := s.buf.String()
+	s.mu.Unlock()
+	return str
+}
+
+func (s *netTestSink) Host(t testing.TB) string {
+	t.Helper()
+	host, _, err := net.SplitHostPort(s.conn.Address().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return host
+}
+
+func (s *netTestSink) Port(t testing.TB) int {
+	t.Helper()
+	_, port, err := net.SplitHostPort(s.conn.Address().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, err := strconv.Atoi(port)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+func (s *netTestSink) Protocol() string {
+	return s.protocol
+}
+
+func mergeEnv(extra ...string) []string {
+	var prefixes []string
+	for _, s := range extra {
+		n := strings.IndexByte(s, '=')
+		prefixes = append(prefixes, s[:n+1])
+	}
+	ignore := func(s string) bool {
+		for _, pfx := range prefixes {
+			if strings.HasPrefix(s, pfx) {
+				return true
+			}
+		}
+		return false
+	}
+
+	env := os.Environ()
+	a := env[:0]
+	for _, s := range env {
+		if !ignore(s) {
+			a = append(a, s)
+		}
+	}
+	return append(a, extra...)
+}
+
+func (s *netTestSink) CommandEnv(t testing.TB) []string {
+	return mergeEnv(
+		fmt.Sprintf("STATSD_PORT=%d", s.Port(t)),
+		fmt.Sprintf("STATSD_HOST=%s", s.Host(t)),
+		fmt.Sprintf("STATSD_PROTOCOL=%s", s.Protocol()),
+		"GOSTATS_FLUSH_INTERVAL_SECONDS=1",
+	)
+}

--- a/settings.go
+++ b/settings.go
@@ -11,6 +11,8 @@ const (
 	DefaultUseStatsd = true
 	// DefaultStatsdHost is the default address where statsd is running at.
 	DefaultStatsdHost = "localhost"
+	// DefaultStatsdProtocol is TCP
+	DefaultStatsdProtocol = "tcp"
 	// DefaultStatsdPort is the default port where statsd is listening at.
 	DefaultStatsdPort = 8125
 	// DefaultFlushIntervalS is the default flushing interval in seconds.
@@ -24,6 +26,8 @@ type Settings struct {
 	UseStatsd bool `envconfig:"USE_STATSD" default:"true"`
 	// Address where statsd is running at.
 	StatsdHost string `envconfig:"STATSD_HOST" default:"localhost"`
+	// Network protocol used to connect to statsd
+	StatsdProtocol string `envconfig:"STATSD_PROTOCOL" default:"tcp"`
 	// Port where statsd is listening at.
 	StatsdPort int `envconfig:"STATSD_PORT" default:"8125"`
 	// Flushing interval.
@@ -90,6 +94,7 @@ func GetSettings() Settings {
 	return Settings{
 		UseStatsd:      useStatsd,
 		StatsdHost:     envOr("STATSD_HOST", DefaultStatsdHost),
+		StatsdProtocol: envOr("STATSD_PROTOCOL", DefaultStatsdProtocol),
 		StatsdPort:     statsdPort,
 		FlushIntervalS: flushIntervalS,
 	}

--- a/settings_test.go
+++ b/settings_test.go
@@ -41,6 +41,7 @@ func TestSettingsCompat(t *testing.T) {
 	reset := testSetenv(t,
 		"USE_STATSD", "",
 		"STATSD_HOST", "",
+		"STATSD_PROTOCOL", "",
 		"STATSD_PORT", "",
 		"GOSTATS_FLUSH_INTERVAL_SECONDS", "",
 	)
@@ -61,6 +62,7 @@ func TestSettingsDefault(t *testing.T) {
 	reset := testSetenv(t,
 		"USE_STATSD", "",
 		"STATSD_HOST", "",
+		"STATSD_PROTOCOL", "",
 		"STATSD_PORT", "",
 		"GOSTATS_FLUSH_INTERVAL_SECONDS", "",
 	)
@@ -68,6 +70,7 @@ func TestSettingsDefault(t *testing.T) {
 	exp := Settings{
 		UseStatsd:      DefaultUseStatsd,
 		StatsdHost:     DefaultStatsdHost,
+		StatsdProtocol: DefaultStatsdProtocol,
 		StatsdPort:     DefaultStatsdPort,
 		FlushIntervalS: DefaultFlushIntervalS,
 	}
@@ -81,6 +84,7 @@ func TestSettingsOverride(t *testing.T) {
 	reset := testSetenv(t,
 		"USE_STATSD", "true",
 		"STATSD_HOST", "10.0.0.1",
+		"STATSD_PROTOCOL", "udp",
 		"STATSD_PORT", "1234",
 		"GOSTATS_FLUSH_INTERVAL_SECONDS", "3",
 	)
@@ -88,6 +92,7 @@ func TestSettingsOverride(t *testing.T) {
 	exp := Settings{
 		UseStatsd:      true,
 		StatsdHost:     "10.0.0.1",
+		StatsdProtocol: "udp",
 		StatsdPort:     1234,
 		FlushIntervalS: 3,
 	}

--- a/stat_handler_wrapper_test.go
+++ b/stat_handler_wrapper_test.go
@@ -3,14 +3,11 @@
 package stats
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 )
 
 func TestHTTPHandler_WrapResponse(t *testing.T) {
-	t.Parallel()
-
 	tests := []http.ResponseWriter{
 		struct {
 			http.ResponseWriter
@@ -98,28 +95,24 @@ func TestHTTPHandler_WrapResponse(t *testing.T) {
 
 	for i, test := range tests {
 		tc := test
-		t.Run(fmt.Sprint("test:", i), func(t *testing.T) {
-			t.Parallel()
+		_, canFlush := tc.(http.Flusher)
+		_, canHijack := tc.(http.Hijacker)
+		_, canPush := tc.(http.Pusher)
+		_, canNotify := tc.(http.CloseNotifier)
 
-			_, canFlush := tc.(http.Flusher)
-			_, canHijack := tc.(http.Hijacker)
-			_, canPush := tc.(http.Pusher)
-			_, canNotify := tc.(http.CloseNotifier)
+		rw := h.wrapResponse(tc)
 
-			rw := h.wrapResponse(tc)
-
-			if _, ok := rw.(http.Flusher); ok != canFlush {
-				t.Errorf("Flusher: wanted %t", canFlush)
-			}
-			if _, ok := rw.(http.Hijacker); ok != canHijack {
-				t.Errorf("Hijacker: wanted %t", canHijack)
-			}
-			if _, ok := rw.(http.Pusher); ok != canPush {
-				t.Errorf("Pusher: wanted %t", canPush)
-			}
-			if _, ok := rw.(http.CloseNotifier); ok != canNotify {
-				t.Errorf("CloseNotifier: wanted %t", canNotify)
-			}
-		})
+		if _, ok := rw.(http.Flusher); ok != canFlush {
+			t.Errorf("Test(%d): Flusher: wanted %t", i, canFlush)
+		}
+		if _, ok := rw.(http.Hijacker); ok != canHijack {
+			t.Errorf("Test(%d): Hijacker: wanted %t", i, canHijack)
+		}
+		if _, ok := rw.(http.Pusher); ok != canPush {
+			t.Errorf("Test(%d): Pusher: wanted %t", i, canPush)
+		}
+		if _, ok := rw.(http.CloseNotifier); ok != canNotify {
+			t.Errorf("Test(%d): CloseNotifier: wanted %t", i, canNotify)
+		}
 	}
 }


### PR DESCRIPTION
This commit adds support for UDP statsd sinks with the STATSD_PROTOCOL
environment variable and the WithStatsdProtocol() SinkOption.

Extends the work initially started with: https://github.com/lyft/gostats/pull/47