### PR TITLE
Support configurable tag prefix and separator

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -32,6 +32,10 @@ type Settings struct {
 	StatsdProtocol string `envconfig:"STATSD_PROTOCOL" default:"tcp"`
 	// Port where statsd is listening at.
 	StatsdPort int `envconfig:"STATSD_PORT" default:"8125"`
+	// Prefix for tags.
+	StatsdTagPrefix string `envconfig:"STATSD_TAG_PREFIX" default:""`
+	// Separator for tag keys and values.
+	StatsdTagSeparator string `envconfig:"STATSD_TAG_SEPARATOR" default:""`
 	// Flushing interval.
 	FlushIntervalS int `envconfig:"GOSTATS_FLUSH_INTERVAL_SECONDS" default:"5"`
 	// Disable the LoggingSink when USE_STATSD is false and use the NullSink instead.

--- a/tags.go
+++ b/tags.go
@@ -183,11 +183,17 @@ func mergeTagSets(s1, s2, scratch tagSet) tagSet {
 	return a[:k]
 }
 
-func serializeTagSet(name string, set tagSet) string {
+func (s *statStore) serializeTagSet(name string, set tagSet) string {
 	// NB: the tagSet must be sorted and have clean values
 
-	const prefix = ".__"
-	const sep = "="
+	prefix := ".__"
+	sep := "="
+	if s.tagPrefix != "" {
+		prefix = s.tagPrefix
+	}
+	if s.tagSeparator != "" {
+		sep = s.tagSeparator
+	}
 
 	if len(set) == 0 {
 		return name
@@ -210,9 +216,15 @@ func serializeTagSet(name string, set tagSet) string {
 	return *(*string)(unsafe.Pointer(&b))
 }
 
-func serializeTags(name string, tags map[string]string) string {
-	const prefix = ".__"
-	const sep = "="
+func (s *statStore) serializeTags(name string, tags map[string]string) string {
+	prefix := ".__"
+	sep := "="
+	if s.tagPrefix != "" {
+		prefix = s.tagPrefix
+	}
+	if s.tagSeparator != "" {
+		sep = s.tagSeparator
+	}
 
 	// discard pairs where the tag or value is an empty string
 	for k, v := range tags {


### PR DESCRIPTION
There are a variety of ways people encode tags into statsd values

Currently gostats does MetricName.__tag1=value1.__tag2=value2

AWS supports something different (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-custom-metrics-statsd.html)
where stats get get reported over TCP as

MetricName:value|type|@sample_rate|#tag1: value1,tag2...

There are other systems out there like https://www.npmjs.com/package/statsd-wavefront-backend/v/0.2.0
which does MetricName_t_tag1_v_value1_t_tag2_v_value2:value|g

The system I'm working with expects MetricName._t_tag1.value2._t_tag2.value2
I don't know all the history behind that format, but seems like there are some
open source projects out there on the internet using formats like that,
like https://github.com/eswdd/opentsdb-statsd-latency/blob/master/src/main/java/uk/co/exemel/opentsdb/StatsdLatencyPlugin.java#L56.

Since statsd doesn't officially support tags, seems like some degree of flexibility
in the protocol is useful.