### PR TITLE
tags: change serializeTags to never modify the tags map

### DIFF
--- a/stats_test.go
+++ b/stats_test.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/lyft/gostats/mock"
 )
 
 // Ensure flushing and adding generators does not race
@@ -86,6 +88,230 @@ func TestNewSubScope(t *testing.T) {
 	if scope.name != "name" {
 		t.Errorf("wrong scope name: %s", scope.name)
 	}
+}
+
+// Test that we never modify the tags map that is passed in
+func TestTagMapNotModified(t *testing.T) {
+	type TagMethod func(scope Scope, name string, tags map[string]string)
+
+	copyTags := func(tags map[string]string) map[string]string {
+		orig := make(map[string]string, len(tags))
+		for k, v := range tags {
+			orig[k] = v
+		}
+		return orig
+	}
+
+	scopeGenerators := map[string]func() Scope{
+		"statStore": func() Scope { return &statStore{} },
+		"subScope":  func() Scope { return newSubScope(&statStore{}, "name", nil) },
+	}
+
+	methodTestCases := map[string]TagMethod{
+		"ScopeWithTags": func(scope Scope, name string, tags map[string]string) {
+			scope.ScopeWithTags(name, tags)
+		},
+		"NewCounterWithTags": func(scope Scope, name string, tags map[string]string) {
+			scope.NewCounterWithTags(name, tags)
+		},
+		"NewPerInstanceCounter": func(scope Scope, name string, tags map[string]string) {
+			scope.NewPerInstanceCounter(name, tags)
+		},
+		"NewGaugeWithTags": func(scope Scope, name string, tags map[string]string) {
+			scope.NewGaugeWithTags(name, tags)
+		},
+		"NewPerInstanceGauge": func(scope Scope, name string, tags map[string]string) {
+			scope.NewPerInstanceGauge(name, tags)
+		},
+		"NewTimerWithTags": func(scope Scope, name string, tags map[string]string) {
+			scope.NewTimerWithTags(name, tags)
+		},
+		"NewPerInstanceTimer": func(scope Scope, name string, tags map[string]string) {
+			scope.NewPerInstanceTimer(name, tags)
+		},
+	}
+
+	tagsTestCases := []map[string]string{
+		{}, // empty
+		{
+			"": "invalid_key",
+		},
+		{
+			"invalid_value": "",
+		},
+		{
+			"":              "invalid_key",
+			"invalid_value": "",
+		},
+		{
+			"_f": "i",
+		},
+		{
+			"":              "invalid_key",
+			"invalid_value": "",
+			"_f":            "i",
+		},
+		{
+			"":              "invalid_key",
+			"invalid_value": "",
+			"_f":            "value",
+			"1":             "1",
+		},
+		{
+			"":              "invalid_key",
+			"invalid_value": "",
+			"1":             "1",
+			"2":             "2",
+			"3":             "3",
+		},
+	}
+
+	for scopeName, newScope := range scopeGenerators {
+		for methodName, method := range methodTestCases {
+			t.Run(scopeName+"."+methodName, func(t *testing.T) {
+				for _, orig := range tagsTestCases {
+					tags := copyTags(orig)
+					method(newScope(), "test", tags)
+					if !reflect.DeepEqual(tags, orig) {
+						t.Errorf("modified input map: %+v want: %+v", tags, orig)
+					}
+				}
+			})
+		}
+
+	}
+}
+
+func TestPerInstanceStats(t *testing.T) {
+	testCases := []struct {
+		expected string
+		tags     map[string]string
+	}{
+		{
+			expected: "name.___f=i",
+			tags:     map[string]string{}, // empty
+		},
+		{
+			expected: "name.___f=i",
+			tags: map[string]string{
+				"": "invalid_key",
+			},
+		},
+		{
+			expected: "name.___f=i",
+			tags: map[string]string{
+				"invalid_value": "",
+			},
+		},
+		{
+			expected: "name.___f=i",
+			tags: map[string]string{
+				"_f": "i",
+			},
+		},
+		{
+			expected: "name.___f=xxx",
+			tags: map[string]string{
+				"_f": "xxx",
+			},
+		},
+		{
+			expected: "name.___f=xxx",
+			tags: map[string]string{
+				"":   "invalid_key",
+				"_f": "xxx",
+			},
+		},
+		{
+			expected: "name.___f=xxx",
+			tags: map[string]string{
+				"invalid_value": "",
+				"_f":            "xxx",
+			},
+		},
+		{
+			expected: "name.___f=xxx",
+			tags: map[string]string{
+				"invalid_value": "",
+				"":              "invalid_key",
+				"_f":            "xxx",
+			},
+		},
+		{
+			expected: "name.__1=1.___f=xxx",
+			tags: map[string]string{
+				"invalid_value": "",
+				"":              "invalid_key",
+				"_f":            "xxx",
+				"1":             "1",
+			},
+		},
+		{
+			expected: "name.__1=1.___f=i",
+			tags: map[string]string{
+				"1": "1",
+			},
+		},
+		{
+			expected: "name.__1=1.__2=2.___f=i",
+			tags: map[string]string{
+				"1": "1",
+				"2": "2",
+			},
+		},
+	}
+
+	sink := mock.NewSink()
+
+	testPerInstanceMethods := func(t *testing.T, scope Scope) {
+		for _, x := range testCases {
+			sink.Reset()
+
+			scope.NewPerInstanceCounter("name", x.tags).Inc()
+			scope.Store().Flush()
+			for key := range sink.Counters() {
+				if key != x.expected {
+					t.Errorf("Counter (%+v): got: %q want: %q", x, key, x.expected)
+				}
+				break
+			}
+
+			scope.NewPerInstanceGauge("name", x.tags).Inc()
+			scope.Store().Flush()
+			for key := range sink.Counters() {
+				if key != x.expected {
+					t.Errorf("Gauge (%+v): got: %q want: %q", x, key, x.expected)
+				}
+				break
+			}
+
+			scope.NewPerInstanceTimer("name", x.tags).AddValue(1)
+			scope.Store().Flush()
+			for key := range sink.Counters() {
+				if key != x.expected {
+					t.Errorf("Timer (%+v): got: %q want: %q", x, key, x.expected)
+				}
+				break
+			}
+		}
+	}
+
+	t.Run("StatsStore", func(t *testing.T) {
+		store := &statStore{sink: sink}
+
+		testPerInstanceMethods(t, store)
+	})
+
+	t.Run("SubScope", func(t *testing.T) {
+		store := &subScope{registry: &statStore{sink: sink}, name: "x"}
+
+		// Add sub-scope prefix to the name
+		for i, x := range testCases {
+			testCases[i].expected = "x." + x.expected
+		}
+
+		testPerInstanceMethods(t, store)
+	})
 }
 
 func mergeTagsReference(s *subScope, tags map[string]string) tagSet {
@@ -410,4 +636,32 @@ func BenchmarkScopeMergeTags(b *testing.B) {
 			})
 		}
 	}
+}
+
+func BenchmarkStoreNewPerInstanceCounter(b *testing.B) {
+	b.Run("HasTag", func(b *testing.B) {
+		var store statStore
+		tags := map[string]string{
+			"1":  "1",
+			"2":  "2",
+			"3":  "3",
+			"_f": "xxx",
+		}
+		for i := 0; i < b.N; i++ {
+			store.NewPerInstanceCounter("name", tags)
+		}
+	})
+
+	b.Run("MissingTag", func(b *testing.B) {
+		var store statStore
+		tags := map[string]string{
+			"1": "1",
+			"2": "2",
+			"3": "3",
+			"4": "4",
+		}
+		for i := 0; i < b.N; i++ {
+			store.NewPerInstanceCounter("name", tags)
+		}
+	})
 }

--- a/tags.go
+++ b/tags.go
@@ -215,23 +215,29 @@ func serializeTags(name string, tags map[string]string) string {
 	const sep = "="
 
 	// discard pairs where the tag or value is an empty string
+	numValid := len(tags)
 	for k, v := range tags {
 		if k == "" || v == "" {
-			delete(tags, k)
+			numValid--
 		}
 	}
 
-	switch len(tags) {
+	switch numValid {
 	case 0:
 		return name
 	case 1:
 		for k, v := range tags {
-			return name + prefix + k + sep + replaceChars(v)
+			if k != "" && v != "" {
+				return name + prefix + k + sep + replaceChars(v)
+			}
 		}
 		panic("unreachable")
 	case 2:
 		var t0, t1 tagPair
 		for k, v := range tags {
+			if k == "" || v == "" {
+				continue
+			}
 			t1 = t0
 			t0 = tagPair{k, replaceChars(v)}
 		}
@@ -243,6 +249,9 @@ func serializeTags(name string, tags map[string]string) string {
 	case 3:
 		var t0, t1, t2 tagPair
 		for k, v := range tags {
+			if k == "" || v == "" {
+				continue
+			}
 			t2 = t1
 			t1 = t0
 			t0 = tagPair{k, replaceChars(v)}
@@ -262,6 +271,9 @@ func serializeTags(name string, tags map[string]string) string {
 	case 4:
 		var t0, t1, t2, t3 tagPair
 		for k, v := range tags {
+			if k == "" || v == "" {
+				continue
+			}
 			t3 = t2
 			t2 = t1
 			t1 = t0
@@ -288,11 +300,14 @@ func serializeTags(name string, tags map[string]string) string {
 			prefix + t3.key + sep + t3.value
 	default:
 		// n stores the length of the serialized name + tags
-		n := (len(prefix) + len(sep)) * len(tags)
+		n := (len(prefix) + len(sep)) * numValid
 		n += len(name)
 
-		pairs := make(tagSet, 0, len(tags))
+		pairs := make(tagSet, 0, numValid)
 		for k, v := range tags {
+			if k == "" || v == "" {
+				continue
+			}
 			n += len(k) + len(v)
 			pairs = append(pairs, tagPair{
 				key:   k,


### PR DESCRIPTION
This changes serializeTags() to not delete entries from the provided
tags map when keys/values are invalid. This prevents a race condition
when users pass the same tags map with invalid entries to
NewCounterWithTags, NewGaugeWithTags, or NewTimerWithTags.