### PR TITLE
Add list of existing stats to assertion not-found failures

### DIFF
--- a/mock/sink.go
+++ b/mock/sink.go
@@ -248,7 +248,7 @@ func (s *Sink) AssertCounterEquals(tb testing.TB, name string, exp uint64) {
 	tb.Helper()
 	u, ok := s.LoadCounter(name)
 	if !ok {
-		tb.Errorf("gostats/mock: Counter (%q): not found in %v", name, s.ListCounters())
+		tb.Errorf("gostats/mock: Counter (%q): not found in: %q", name, s.ListCounters())
 		return
 	}
 	if u != exp {
@@ -261,7 +261,7 @@ func (s *Sink) AssertGaugeEquals(tb testing.TB, name string, exp uint64) {
 	tb.Helper()
 	u, ok := s.LoadGauge(name)
 	if !ok {
-		tb.Errorf("gostats/mock: Gauge (%q): not found in %v", name, s.ListGauges())
+		tb.Errorf("gostats/mock: Gauge (%q): not found in: %q", name, s.ListGauges())
 		return
 	}
 	if u != exp {
@@ -274,7 +274,7 @@ func (s *Sink) AssertTimerEquals(tb testing.TB, name string, exp float64) {
 	tb.Helper()
 	f, ok := s.LoadTimer(name)
 	if !ok {
-		tb.Errorf("gostats/mock: Timer (%q): not found in %v", name, s.ListTimers())
+		tb.Errorf("gostats/mock: Timer (%q): not found in: %q", name, s.ListTimers())
 		return
 	}
 	if f != exp {
@@ -286,7 +286,7 @@ func (s *Sink) AssertTimerEquals(tb testing.TB, name string, exp float64) {
 func (s *Sink) AssertCounterExists(tb testing.TB, name string) {
 	tb.Helper()
 	if _, ok := s.LoadCounter(name); !ok {
-		tb.Errorf("gostats/mock: Counter (%q): not found in %v", name, s.ListCounters())
+		tb.Errorf("gostats/mock: Counter (%q): not found in: %q", name, s.ListCounters())
 	}
 }
 
@@ -294,7 +294,7 @@ func (s *Sink) AssertCounterExists(tb testing.TB, name string) {
 func (s *Sink) AssertGaugeExists(tb testing.TB, name string) {
 	tb.Helper()
 	if _, ok := s.LoadGauge(name); !ok {
-		tb.Errorf("gostats/mock: Gauge (%q): not found in %v", name, s.ListGauges())
+		tb.Errorf("gostats/mock: Gauge (%q): not found in: %q", name, s.ListGauges())
 	}
 }
 
@@ -302,7 +302,7 @@ func (s *Sink) AssertGaugeExists(tb testing.TB, name string) {
 func (s *Sink) AssertTimerExists(tb testing.TB, name string) {
 	tb.Helper()
 	if _, ok := s.LoadTimer(name); !ok {
-		tb.Errorf("gostats/mock: Timer (%q): not found in %v", name, s.ListTimers())
+		tb.Errorf("gostats/mock: Timer (%q): not found in: %q", name, s.ListTimers())
 	}
 }
 
@@ -335,7 +335,7 @@ func (s *Sink) AssertCounterCallCount(tb testing.TB, name string, exp int) {
 	tb.Helper()
 	v, ok := s.counters().Load(name)
 	if !ok {
-		tb.Errorf("gostats/mock: Counter (%q): not found in %v", name, s.ListCounters())
+		tb.Errorf("gostats/mock: Counter (%q): not found in: %q", name, s.ListCounters())
 		return
 	}
 	p := v.(*entry)
@@ -351,7 +351,7 @@ func (s *Sink) AssertGaugeCallCount(tb testing.TB, name string, exp int) {
 	tb.Helper()
 	v, ok := s.gauges().Load(name)
 	if !ok {
-		tb.Errorf("gostats/mock: Gauge (%q): not found in %v", name, s.ListGauges())
+		tb.Errorf("gostats/mock: Gauge (%q): not found in: %q", name, s.ListGauges())
 		return
 	}
 	p := v.(*entry)
@@ -367,7 +367,7 @@ func (s *Sink) AssertTimerCallCount(tb testing.TB, name string, exp int) {
 	tb.Helper()
 	v, ok := s.timers().Load(name)
 	if !ok {
-		tb.Errorf("gostats/mock: Timer (%q): not found in %v", name, s.ListTimers())
+		tb.Errorf("gostats/mock: Timer (%q): not found in: %q", name, s.ListTimers())
 		return
 	}
 	p := v.(*entry)

--- a/mock/sink.go
+++ b/mock/sink.go
@@ -134,6 +134,30 @@ func (s *Sink) LoadTimer(name string) (float64, bool) {
 	return 0, false
 }
 
+// ListCounters returns a list of existing counter names.
+func (s *Sink) ListCounters() []string {
+	return keys(s.counters())
+}
+
+// ListGauges returns a list of existing gauge names.
+func (s *Sink) ListGauges() []string {
+	return keys(s.gauges())
+}
+
+// ListTimers returns a list of existing timer names.
+func (s *Sink) ListTimers() []string {
+	return keys(s.timers())
+}
+
+// Note, this may return an incoherent snapshot if contents is being concurrently modified
+func keys(m *sync.Map) (a []string) {
+	m.Range(func(key interface{}, _ interface{}) bool {
+		a = append(a, key.(string))
+		return true
+	})
+	return a
+}
+
 // Counters returns all the counters currently stored by the sink.
 func (s *Sink) Counters() map[string]uint64 {
 	m := make(map[string]uint64)
@@ -224,7 +248,7 @@ func (s *Sink) AssertCounterEquals(tb testing.TB, name string, exp uint64) {
 	tb.Helper()
 	u, ok := s.LoadCounter(name)
 	if !ok {
-		tb.Errorf("gostats/mock: Counter (%q): not found", name)
+		tb.Errorf("gostats/mock: Counter (%q): not found in %v", name, s.ListCounters())
 		return
 	}
 	if u != exp {
@@ -237,7 +261,7 @@ func (s *Sink) AssertGaugeEquals(tb testing.TB, name string, exp uint64) {
 	tb.Helper()
 	u, ok := s.LoadGauge(name)
 	if !ok {
-		tb.Errorf("gostats/mock: Gauge (%q): not found", name)
+		tb.Errorf("gostats/mock: Gauge (%q): not found in %v", name, s.ListGauges())
 		return
 	}
 	if u != exp {
@@ -250,7 +274,7 @@ func (s *Sink) AssertTimerEquals(tb testing.TB, name string, exp float64) {
 	tb.Helper()
 	f, ok := s.LoadTimer(name)
 	if !ok {
-		tb.Errorf("gostats/mock: Timer (%q): not found", name)
+		tb.Errorf("gostats/mock: Timer (%q): not found in %v", name, s.ListTimers())
 		return
 	}
 	if f != exp {
@@ -262,7 +286,7 @@ func (s *Sink) AssertTimerEquals(tb testing.TB, name string, exp float64) {
 func (s *Sink) AssertCounterExists(tb testing.TB, name string) {
 	tb.Helper()
 	if _, ok := s.LoadCounter(name); !ok {
-		tb.Errorf("gostats/mock: Counter (%q): not found", name)
+		tb.Errorf("gostats/mock: Counter (%q): not found in %v", name, s.ListCounters())
 	}
 }
 
@@ -270,7 +294,7 @@ func (s *Sink) AssertCounterExists(tb testing.TB, name string) {
 func (s *Sink) AssertGaugeExists(tb testing.TB, name string) {
 	tb.Helper()
 	if _, ok := s.LoadGauge(name); !ok {
-		tb.Errorf("gostats/mock: Gauge (%q): not found", name)
+		tb.Errorf("gostats/mock: Gauge (%q): not found in %v", name, s.ListGauges())
 	}
 }
 
@@ -278,7 +302,7 @@ func (s *Sink) AssertGaugeExists(tb testing.TB, name string) {
 func (s *Sink) AssertTimerExists(tb testing.TB, name string) {
 	tb.Helper()
 	if _, ok := s.LoadTimer(name); !ok {
-		tb.Errorf("gostats/mock: Timer (%q): not found", name)
+		tb.Errorf("gostats/mock: Timer (%q): not found in %v", name, s.ListTimers())
 	}
 }
 
@@ -311,7 +335,7 @@ func (s *Sink) AssertCounterCallCount(tb testing.TB, name string, exp int) {
 	tb.Helper()
 	v, ok := s.counters().Load(name)
 	if !ok {
-		tb.Errorf("gostats/mock: Counter (%q): not found", name)
+		tb.Errorf("gostats/mock: Counter (%q): not found in %v", name, s.ListCounters())
 		return
 	}
 	p := v.(*entry)
@@ -327,7 +351,7 @@ func (s *Sink) AssertGaugeCallCount(tb testing.TB, name string, exp int) {
 	tb.Helper()
 	v, ok := s.gauges().Load(name)
 	if !ok {
-		tb.Errorf("gostats/mock: Gauge (%q): not found", name)
+		tb.Errorf("gostats/mock: Gauge (%q): not found in %v", name, s.ListGauges())
 		return
 	}
 	p := v.(*entry)
@@ -343,7 +367,7 @@ func (s *Sink) AssertTimerCallCount(tb testing.TB, name string, exp int) {
 	tb.Helper()
 	v, ok := s.timers().Load(name)
 	if !ok {
-		tb.Errorf("gostats/mock: Timer (%q): not found", name)
+		tb.Errorf("gostats/mock: Timer (%q): not found in %v", name, s.ListTimers())
 		return
 	}
 	p := v.(*entry)

--- a/mock/sink_test.go
+++ b/mock/sink_test.go
@@ -69,7 +69,7 @@ func TestSink(t *testing.T) {
 			func(t testing.TB) { sink.AssertCounterCallCount(t, missing, 9999) },
 		}
 		for _, fn := range fns {
-			AssertErrorMsg(t, fn, "gostats/mock: Counter (%q): not found", missing)
+			AssertErrorMsg(t, fn, "gostats/mock: Counter (%q): not found in [test-counter]", missing)
 		}
 
 		AssertErrorMsg(t, func(t testing.TB) {
@@ -104,7 +104,7 @@ func TestSink(t *testing.T) {
 			func(t testing.TB) { sink.AssertGaugeCallCount(t, missing, 9999) },
 		}
 		for _, fn := range fns {
-			AssertErrorMsg(t, fn, "gostats/mock: Gauge (%q): not found", missing)
+			AssertErrorMsg(t, fn, "gostats/mock: Gauge (%q): not found in [test-gauge]", missing)
 		}
 
 		AssertErrorMsg(t, func(t testing.TB) {
@@ -139,7 +139,7 @@ func TestSink(t *testing.T) {
 			func(t testing.TB) { sink.AssertTimerCallCount(t, missing, 9999) },
 		}
 		for _, fn := range fns {
-			AssertErrorMsg(t, fn, "gostats/mock: Timer (%q): not found", missing)
+			AssertErrorMsg(t, fn, "gostats/mock: Timer (%q): not found in [test-timer]", missing)
 		}
 
 		AssertErrorMsg(t, func(t testing.TB) {

--- a/mock/sink_test.go
+++ b/mock/sink_test.go
@@ -69,7 +69,7 @@ func TestSink(t *testing.T) {
 			func(t testing.TB) { sink.AssertCounterCallCount(t, missing, 9999) },
 		}
 		for _, fn := range fns {
-			AssertErrorMsg(t, fn, "gostats/mock: Counter (%q): not found in [test-counter]", missing)
+			AssertErrorMsg(t, fn, "gostats/mock: Counter (%q): not found in: [\"test-counter\"]", missing)
 		}
 
 		AssertErrorMsg(t, func(t testing.TB) {
@@ -104,7 +104,7 @@ func TestSink(t *testing.T) {
 			func(t testing.TB) { sink.AssertGaugeCallCount(t, missing, 9999) },
 		}
 		for _, fn := range fns {
-			AssertErrorMsg(t, fn, "gostats/mock: Gauge (%q): not found in [test-gauge]", missing)
+			AssertErrorMsg(t, fn, "gostats/mock: Gauge (%q): not found in: [\"test-gauge\"]", missing)
 		}
 
 		AssertErrorMsg(t, func(t testing.TB) {
@@ -139,7 +139,7 @@ func TestSink(t *testing.T) {
 			func(t testing.TB) { sink.AssertTimerCallCount(t, missing, 9999) },
 		}
 		for _, fn := range fns {
-			AssertErrorMsg(t, fn, "gostats/mock: Timer (%q): not found in [test-timer]", missing)
+			AssertErrorMsg(t, fn, "gostats/mock: Timer (%q): not found in: [\"test-timer\"]", missing)
 		}
 
 		AssertErrorMsg(t, func(t testing.TB) {


### PR DESCRIPTION
In more complex cases (e.g. with use of tags, deeply nested scopes), it is not always super obvious what the full name of a metric will end up being. This change lists the names of all recorded metrics in the failure message for assertions that fail due to an expected metric not being found, so that you can easily compare the expected metric name to the actually-generated metric name.