### PR TITLE
net_util_test: Reconnect() retry if the error is due to EADDRINUSE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo:     required
 language: go
 go:
-  - "1.12.x"
   - "1.13.x"
+  - "1.14.x"
+  - "1.15.x"
 
 before_install: mkdir -p $GOPATH/bin
 install:        make install


### PR DESCRIPTION
This commit changes the Reconnect() methods to retry making the
connection is the error is due to the address being in use (EADDRINUSE).
This should fix some flakiness we've seen in CI.