### PR TITLE
net_util_test: fix and test reconnect retry logic

### DIFF
--- a/net_sink_test.go
+++ b/net_sink_test.go
@@ -666,12 +666,12 @@ func testNetSinkReconnect(t *testing.T, protocol string) {
 	// This test is flaky with UDP and the race detector, but good
 	// to have so we log instead of fail the test.
 	if protocol == "udp" {
-		stat := ts.WaitForStat(replaceFatalWithLog{t}, defaultRetryInterval*2)
+		stat := ts.WaitForStat(replaceFatalWithLog{t}, defaultRetryInterval*3)
 		if stat != "" && stat != expected {
 			t.Fatalf("stats got: %q want: %q", stat, expected)
 		}
 	} else {
-		stat := ts.WaitForStat(t, defaultRetryInterval*2)
+		stat := ts.WaitForStat(t, defaultRetryInterval*3)
 		if stat != expected {
 			t.Fatalf("stats got: %q want: %q", stat, expected)
 		}


### PR DESCRIPTION
This commit fixes the reconnect retry logic that was added with: https://github.com/lyft/gostats/pull/106. 
The issue was that the arguments to errors.Is() were switched.