### PR TITLE
tests: disable running tests in parallel in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ go:
   - "1.14.x"
   - "1.15.x"
 
+# The "travis" build tag disables running tests in parallel.
+# We this because Travis is slow (and sadly some of the tests
+# tests must be timeout based).
+env:
+  - GOFLAGS='-tags=travis'
+
 before_install: mkdir -p $GOPATH/bin
 install:        make install
 script:         make lint quick test

--- a/net_sink_test.go
+++ b/net_sink_test.go
@@ -642,7 +642,7 @@ func testNetSinkReconnect(t *testing.T, protocol string) {
 	if testing.Short() {
 		t.Skip("Skipping: short test")
 	}
-	t.Parallel()
+	Parallel(t)
 
 	const expected = "counter:1|c\n"
 
@@ -692,7 +692,7 @@ func testNetSinkReconnectFailure(t *testing.T, protocol string) {
 	if testing.Short() {
 		t.Skip("Skipping: short test")
 	}
-	t.Parallel()
+	Parallel(t)
 
 	ts, sink := setupTestNetSink(t, protocol, true)
 	defer ts.Close()
@@ -794,7 +794,7 @@ func buildBinary(t testing.TB, path string) (string, func()) {
 }
 
 func testNetSinkIntegration(t *testing.T, protocol string) {
-	t.Parallel()
+	Parallel(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/net_util_test.go
+++ b/net_util_test.go
@@ -359,7 +359,7 @@ func reconnectRetry(t testing.TB, fn func() error) {
 }
 
 func TestReconnectRetryTCP(t *testing.T) {
-	t.Parallel()
+	Parallel(t)
 
 	l1, err := net.ListenTCP("tcp", &net.TCPAddr{
 		IP:   net.IPv4(127, 0, 0, 1),
@@ -397,7 +397,7 @@ func TestReconnectRetryTCP(t *testing.T) {
 }
 
 func TestReconnectRetryUDP(t *testing.T) {
-	t.Parallel()
+	Parallel(t)
 
 	l1, err := net.ListenUDP("udp", &net.UDPAddr{
 		IP:   net.IPv4(127, 0, 0, 1),

--- a/parallel_ci_test.go
+++ b/parallel_ci_test.go
@@ -1,0 +1,8 @@
+// +build travis
+
+package stats
+
+import "testing"
+
+// Travis CI is really slow - so don't run tests in parallel.
+func Parallel(t *testing.T) { /* no-op */ }

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -1,0 +1,7 @@
+// +build !travis
+
+package stats
+
+import "testing"
+
+func Parallel(t *testing.T) { t.Parallel() }

--- a/stat_handler_test.go
+++ b/stat_handler_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestHttpHandler_ServeHTTP(t *testing.T) {
-	t.Parallel()
+	Parallel(t)
 
 	sink := mock.NewSink()
 	store := NewStore(sink, false)

--- a/stat_handler_wrapper_1.7_test.go
+++ b/stat_handler_wrapper_1.7_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestHTTPHandler_WrapResponse(t *testing.T) {
-	t.Parallel()
+	Parallel(t)
 
 	tests := []http.ResponseWriter{
 		struct {
@@ -57,7 +57,7 @@ func TestHTTPHandler_WrapResponse(t *testing.T) {
 	for i, test := range tests {
 		tc := test
 		t.Run(fmt.Sprint("test:", i), func(t *testing.T) {
-			t.Parallel()
+			Parallel(t)
 
 			_, canFlush := tc.(http.Flusher)
 			_, canHijack := tc.(http.Hijacker)


### PR DESCRIPTION
Travis CI is slow and this makes tests that have timeouts flaky. We could increase the timeouts, but that would slow the feedback cycle of local development. Instead this commit disables running tests in parallel when the 'travis' build tag is provided (I had some spicier names for it, but I considering this is OSS 'travis' will do).

Note: we do not rely on tests being parallel to identify race conditions we do that explicitly and often.