### PR TITLE
Retry failed writes once

### DIFF
--- a/net_sink.go
+++ b/net_sink.go
@@ -110,7 +110,7 @@ func NewNetSink(opts ...SinkOption) FlushableSink {
 	}
 
 	s.outc = make(chan *bytes.Buffer, approxMaxMemBytes/bufSize)
-	s.retryc = make(chan *bytes.Buffer, approxMaxMemBytes/bufSize)
+	s.retryc = make(chan *bytes.Buffer, 1) // It should be okay to limit this given we preferentially process from this over outc.
 
 	writer := &sinkWriter{outc: s.outc}
 	s.bufWriter = bufio.NewWriterSize(writer, bufSize)

--- a/net_sink.go
+++ b/net_sink.go
@@ -109,12 +109,10 @@ func NewNetSink(opts ...SinkOption) FlushableSink {
 		bufSize = defaultBufferSizeTCP
 	}
 
-	outc := make(chan *bytes.Buffer, approxMaxMemBytes/bufSize)
-	writer := &sinkWriter{
-		outc: outc,
-	}
-	s.outc = outc
+	s.outc = make(chan *bytes.Buffer, approxMaxMemBytes/bufSize)
+	s.retryc = make(chan *bytes.Buffer, approxMaxMemBytes/bufSize)
 
+	writer := &sinkWriter{outc: s.outc}
 	s.bufWriter = bufio.NewWriterSize(writer, bufSize)
 
 	go s.run()
@@ -124,6 +122,7 @@ func NewNetSink(opts ...SinkOption) FlushableSink {
 type netSink struct {
 	conn         net.Conn
 	outc         chan *bytes.Buffer
+	retryc       chan *bytes.Buffer
 	mu           sync.Mutex
 	bufWriter    *bufio.Writer
 	doFlush      chan chan struct{}
@@ -305,12 +304,25 @@ func (s *netSink) run() {
 			n := len(s.outc)
 			for i := 0; i < n && s.conn != nil; i++ {
 				buf := <-s.outc
-				s.writeToConn(buf)
+				if err := s.writeToConn(buf); err != nil {
+					s.retryc <- buf
+					continue
+				}
 				putBuffer(buf)
 			}
 			close(done)
 		case buf := <-s.outc:
-			s.writeToConn(buf)
+			if err := s.writeToConn(buf); err != nil {
+				s.retryc <- buf
+				continue
+			}
+			putBuffer(buf)
+		case buf := <-s.retryc:
+			if err := s.writeToConn(buf); err != nil {
+				s.mu.Lock()
+				s.handleFlushErrorSize(err, buf.Len())
+				s.mu.Unlock()
+			}
 			putBuffer(buf)
 		}
 	}
@@ -318,21 +330,17 @@ func (s *netSink) run() {
 
 // writeToConn writes the buffer to the underlying conn.  May only be called
 // from run().
-func (s *netSink) writeToConn(buf *bytes.Buffer) {
-	len := buf.Len()
-
+func (s *netSink) writeToConn(buf *bytes.Buffer) error {
 	// TODO (CEV): parameterize timeout
 	s.conn.SetWriteDeadline(time.Now().Add(defaultWriteTimeout))
 	_, err := buf.WriteTo(s.conn)
 	s.conn.SetWriteDeadline(time.Time{}) // clear
 
 	if err != nil {
-		s.mu.Lock()
-		s.handleFlushErrorSize(err, len)
-		s.mu.Unlock()
 		_ = s.conn.Close()
 		s.conn = nil // this will break the loop
 	}
+	return err
 }
 
 func (s *netSink) connect(address string) error {

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -14,14 +14,13 @@ func TestRuntime(t *testing.T) {
 	g.GenerateStats()
 	store.Flush()
 
-	pattern :=
-		`runtime.lastGC:\d+|g\n` +
-			`runtime.pauseTotalNs:\d+|g\n` +
-			`runtime.numGC:\d+|g\n` +
-			`runtime.alloc:\d+|g\n` +
-			`runtime.totalAlloc:\d+|g\n` +
-			`runtime.frees:\d+|g\n` +
-			`runtime.nextGC:\d+|g\n`
+	pattern := `runtime.lastGC:\d+|g\n` +
+		`runtime.pauseTotalNs:\d+|g\n` +
+		`runtime.numGC:\d+|g\n` +
+		`runtime.alloc:\d+|g\n` +
+		`runtime.totalAlloc:\d+|g\n` +
+		`runtime.frees:\d+|g\n` +
+		`runtime.nextGC:\d+|g\n`
 
 	ok, err := regexp.Match(pattern, []byte(sink.record))
 	if err != nil {


### PR DESCRIPTION
I periodically see messages in the vein of "write: broken pipe" which I suspect come from the underlying connection being closed. Typically, the next write succeeds because a new connection is established, but the data is lost and the logs are muddied.

This PR introduces a retry channel so that buffers we failed to flush the first time get one more chance. Given the way the core netSink.run loop works, a write that failed because of a bad connection will get a new connection, then those messages enqueued for a retry will get their chance. The failure handling is moved accordingly--only after a retried write fails will we abandon the data and acknowledge it with a log.