### PR TITLE
introduce MilliTimer

### DIFF
--- a/stats_test.go
+++ b/stats_test.go
@@ -58,6 +58,21 @@ func TestTimer(t *testing.T) {
 	}
 }
 
+// Ensure millitimers and timespans are working
+func TestMilliTimer(t *testing.T) {
+	testDuration := 420 * time.Millisecond
+	sink := &testStatSink{}
+	store := NewStore(sink, true)
+	store.NewMilliTimer("test").AllocateSpan().CompleteWithDuration(testDuration)
+	store.Flush()
+
+	expected := "test:420.000000|ms"
+	timer := sink.record
+	if !strings.Contains(timer, expected) {
+		t.Error("wanted timer value of test:420.000000|ms, got", timer)
+	}
+}
+
 // Ensure 0 counters are flushed
 func TestZeroCounters(t *testing.T) {
 	sink := &testStatSink{}


### PR DESCRIPTION
This provides an API so that we can move away from microsecond-based
timers.

The StatsD spec suggests using milliseconds, and they're a great fit
for the typical RPCs we are measuring. Most RPCs take about
1-1000ms, which makes it easy for a human to spot and tell the
difference vs. microseconds which would be 1000us-1000000us. We don't
need that amount of fidelity.

Consumers can continue using NewTimer, using microseconds, which might
be appropriate for other use cases like timing functions. But most new
callers should move toward MilliTimer functions.