### PR TITLE
don't flush zero counters

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -333,7 +333,10 @@ func (s *statStore) Flush() {
 	s.genMtx.RUnlock()
 
 	s.counters.Range(func(key, v interface{}) bool {
-		s.sink.FlushCounter(key.(string), v.(*counter).latch())
+		// do not flush counters that are set to zero
+		if value := v.(*counter).latch(); value != 0 {
+			s.sink.FlushCounter(key.(string), value)
+		}
 		return true
 	})
 

--- a/stats_test.go
+++ b/stats_test.go
@@ -73,14 +73,14 @@ func TestMilliTimer(t *testing.T) {
 	}
 }
 
-// Ensure 0 counters are flushed
+// Ensure 0 counters are not flushed
 func TestZeroCounters(t *testing.T) {
 	sink := &testStatSink{}
 	store := NewStore(sink, true)
 	store.NewCounter("test")
 	store.Flush()
 
-	expected := "test:0|c\n"
+	expected := ""
 	counter := sink.record
 	if counter != expected {
 		t.Errorf("wanted %q got %q", expected, counter)


### PR DESCRIPTION
This undoes a change in 0ed02ca2404195b02e124f16685a53046bbafa06,
which always emitted counters even when if the value was set to zero,
i.e. declared, but never incremented.

The idea behind changing this back is to have some consistency - some
orgs like to skip sending zeros in order to save on network costs;
when sending them, aggregation systems tend to drop them anyway. It's
best to not emit them at all.
