### PR TITLE
add StartContext, remove Stop

### DIFF
--- a/stats_test.go
+++ b/stats_test.go
@@ -1,6 +1,7 @@
 package stats
 
 import (
+	"context"
 	crand "crypto/rand"
 	"encoding/hex"
 	"fmt"
@@ -43,70 +44,29 @@ func TestStats(t *testing.T) {
 	wg.Wait()
 }
 
-// TestStatsStartMultipleTimes ensures starting a periodic flush twice
-// works as expected.
-func TestStatsStartMultipleTimes(t *testing.T) {
+// TestStatsStartContext ensures that a cancelled context cancels a
+// flushing goroutine.
+func TestStatsStartContext(t *testing.T) {
 	sink := &testStatSink{}
 	store := NewStore(sink, true)
 
-	// we check to make sure the two stop channels are different,
-	// that's the best we can do.
-	store.Start(time.NewTicker(1 * time.Minute))
+	ctx, cancel := context.WithCancel(context.Background())
+	tick := time.NewTicker(1 * time.Minute)
 
-	// grab the stop channel
-	realStore := store.(*statStore)
-	stopChan1 := realStore.stop
+	wg := &sync.WaitGroup{}
 
-	store.Start(time.NewTicker(10 * time.Hour))
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		store.StartContext(ctx, tick)
+	}()
 
-	// grab the new stop channel
-	stopChan2 := realStore.stop
+	// now we cancel, and its ok to do this at any point - the
+	// goroutine above could have started or not started, either case
+	// is ok.
+	cancel()
 
-	if stopChan1 == stopChan2 {
-		t.Error("two stop channels are the same")
-	}
-}
-
-// TestStatsStartStop ensures starting a periodic flush can be
-// stopped.
-func TestStatsStartStop(t *testing.T) {
-	sink := &testStatSink{}
-	store := NewStore(sink, true)
-
-	store.Start(time.NewTicker(1 * time.Minute))
-	store.Stop()
-
-	realStore := store.(*statStore)
-
-	// we check to make sure the two stop channel is nil'ed out, that
-	// is the best we can do to avoid flakey time based tests.
-	if realStore.stop != nil {
-		t.Errorf("expected stop channel to be nil")
-	}
-}
-
-// TestStatsStartStopMultipleTimes ensures starting a periodic flush
-// can be stopped, even if called multiple times.
-func TestStatsStartStopMultipleTimes(t *testing.T) {
-	sink := &testStatSink{}
-	store := NewStore(sink, true)
-
-	// ensure we can call it if no ticker was ever started
-	store.Stop()
-
-	// start one, and stop many times.
-	store.Start(time.NewTicker(1 * time.Minute))
-	store.Stop()
-	store.Stop()
-	store.Stop()
-
-	realStore := store.(*statStore)
-
-	// we check to make sure the two stop channel is nil'ed out, that
-	// is the best we can do to avoid flakey time based tests.
-	if realStore.stop != nil {
-		t.Errorf("expected stop channel to be nil")
-	}
+	wg.Wait()
 }
 
 // Ensure timers and timespans are working


### PR DESCRIPTION
This change removes the Stop() method from the previous change, and fixes the Start behavior to be backwards compatible.

The previous change changed the behavior of Start() to be non-blocking from blocking. This is a change in API that we should revert. Stop is also removed - even though this too is a breaking change this is not a 1.0 release and the release is short-lived as of right now.

This change introduces a new method, StartContext, which should achieve the goals from the last change, but retain backwards compatibility.

StartContext is a blocking call like Start is, but allows for a context to be passed in, thus allowing for cancellation.