### PR TITLE
logger interface update

### DIFF
--- a/logging_sink.go
+++ b/logging_sink.go
@@ -96,10 +96,10 @@ func (s *loggingSink) Flush() { s.log("", "all stats", 0) }
 
 // Logger
 
-func (s *loggingSink) Errorf(msg string, args ...interface{}) {
-	s.logMessage("error", fmt.Sprintf(msg, args...))
+func (s *loggingSink) Error(msg string, args ...interface{}) {
+	s.logMessage("error", msg)
 }
 
-func (s *loggingSink) Warnf(msg string, args ...interface{}) {
-	s.logMessage("warn", fmt.Sprintf(msg, args...))
+func (s *loggingSink) Warn(msg string, args ...interface{}) {
+	s.logMessage("warn", msg)
 }


### PR DESCRIPTION
This comment is no longer true:

```
// For convenience of transitioning from logrus to zap, this interface
// conforms BOTH to logrus.Logger as well as the Zap's Sugared logger.
type Logger interface {
	Errorf(msg string, args ...interface{})
	Warnf(msg string, args ...interface{})
}
```

zap no longer has these methods: https://github.com/uber-go/zap/blob/master/logger.go
