### PR TITLE
target only upstream supported versions of Go

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,9 +8,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.17.x
-          - 1.18.x
           - 1.19.x
+          - 1.20.x
 
     name: run-tests
     runs-on: ubuntu-latest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,6 @@
 linters:
   disable-all: true
   enable:
-    - depguard
     - gofumpt
     - goimports
     - gosimple

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/lyft/gostats
 
-go 1.17
+go 1.18
 
 require github.com/kelseyhightower/envconfig v1.4.0

--- a/mock/sink_test.go
+++ b/mock/sink_test.go
@@ -291,7 +291,7 @@ func TestSink_ThreadSafe(t *testing.T) {
 	sink.AssertGaugeEquals(t, "name", uint64(1))
 }
 
-func TestSink_ThreadSafe_Reset(t *testing.T) {
+func TestSink_ThreadSafe_Reset(_ *testing.T) {
 	const N = 2000
 	sink := mock.NewSink()
 	funcs := [...]func(){

--- a/mock_sink.go
+++ b/mock_sink.go
@@ -44,7 +44,7 @@ func (m *MockSink) FlushGauge(name string, value uint64) {
 }
 
 // FlushTimer satisfies the Sink interface.
-func (m *MockSink) FlushTimer(name string, value float64) {
+func (m *MockSink) FlushTimer(name string, value float64) { //nolint:revive
 	m.tLock.Lock()
 	defer m.tLock.Unlock()
 	m.Timers[name]++

--- a/null_sink.go
+++ b/null_sink.go
@@ -7,10 +7,10 @@ func NewNullSink() FlushableSink {
 	return nullSink{}
 }
 
-func (s nullSink) FlushCounter(name string, value uint64) {}
+func (s nullSink) FlushCounter(name string, value uint64) {} //nolint:revive
 
-func (s nullSink) FlushGauge(name string, value uint64) {}
+func (s nullSink) FlushGauge(name string, value uint64) {} //nolint:revive
 
-func (s nullSink) FlushTimer(name string, value float64) {}
+func (s nullSink) FlushTimer(name string, value float64) {} //nolint:revive
 
 func (s nullSink) Flush() {}

--- a/stats_test.go
+++ b/stats_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Ensure flushing and adding generators does not race
-func TestStats(t *testing.T) {
+func TestStats(_ *testing.T) {
 	sink := &testStatSink{}
 	store := NewStore(sink, true)
 
@@ -46,7 +46,7 @@ func TestStats(t *testing.T) {
 
 // TestStatsStartContext ensures that a cancelled context cancels a
 // flushing goroutine.
-func TestStatsStartContext(t *testing.T) {
+func TestStatsStartContext(_ *testing.T) {
 	sink := &testStatSink{}
 	store := NewStore(sink, true)
 


### PR DESCRIPTION
As per the [Golang release policy](https://go.dev/doc/devel/release#policy):

>Each major Go release is supported until there are two newer major releases.

`gostats` doesn't need to support `1.17` or `1.18` anymore, so:

- Change unit test suite to target currently supported versions of Go.
- Change the `go.mod` version to be `1.18` to mark that we will need generics support in https://github.com/lyft/gostats/pull/158.

Also going through and fixing lint errors with 325decb so that this PR can be merged.