### PR TITLE
add support to batch metric and send on a strict interval

### DIFF
--- a/net_sink.go
+++ b/net_sink.go
@@ -285,8 +285,9 @@ func (s *netSink) run() {
 	t := time.NewTicker(flushInterval)
 	defer t.Stop()
 
-	// stat flush and write loop
+	// flush all buffered stats and send loop
 	for {
+		// writeToConn will set s.conn to nil on error, try to reconnect
 		if s.conn == nil {
 			if err := s.connect(addr); err != nil {
 				s.log.Warnf("connection error: %s", err)
@@ -324,11 +325,24 @@ func (s *netSink) run() {
 			batch = s.sendBatch(batch)
 		}
 
-		// flush to outc and batch and/or send outc
+		// flush buffer to outc and batch and/or send outc
 		select {
+		case <-t.C:
+			s.flush() // from a higher level, stats are written to s.bufWriter.buf at GOSTATS_FLUSH_INTERVAL_SECONDS (or adhoc for Timers). this flushes them to outc every t.C tick
 		case done := <-s.doFlush:
 			// send batched outc data
 			batch = s.sendBatch(batch)
+
+			// drain and send remaining outc data
+			// todo re-evaluate: this code is probably redundant, outc should naturally become empty with `case buf := <-s.outc`, why is a forced drain required?
+			n := len(s.outc) // Only flush pending buffers, this prevents an issue where continuous writes prevent the flush loop from exiting.
+			for i := 0; i < n && s.conn != nil; i++ {
+				buf := <-s.outc
+				if err := s.send(buf); err == nil {
+					putBuffer(buf)
+				}
+			}
+
 			close(done)
 		case buf := <-s.outc:
 			if isBatchEnabled {
@@ -340,8 +354,6 @@ func (s *netSink) run() {
 			if err := s.send(buf); err == nil {
 				putBuffer(buf)
 			}
-		case <-t.C:
-			s.flush() // from a higher level, stats are written to s.bufWriter.buf at GOSTATS_FLUSH_INTERVAL_SECONDS (or adhoc for Timers). this flushes them to outc every t.C tick
 		}
 	}
 }

--- a/net_sink.go
+++ b/net_sink.go
@@ -355,7 +355,7 @@ func (s *netSink) run() {
 			}
 			putBuffer(buf) // todo understand: we write the stats buffer we have successfully sent to a pool, but anytime we access data from that pool, we clear it and reuse the allocation for the next stat
 		case <-t.C:
-			// todo find out what happens if this channel is full
+			// todo understand: if the outc channel is full this will block? but it won't ever since it's the last select
 			s.flush() // from a higher level, stats write to s.bufWriter at GOSTATS_FLUSH_INTERVAL_SECONDS (or adhoc for Timers). this flushes them to outc every t.C tick
 		}
 	}

--- a/net_sink.go
+++ b/net_sink.go
@@ -389,7 +389,7 @@ func (s *netSink) sendBatch(batch []bytes.Buffer) ([]bytes.Buffer, error) {
 	var i int
 	for i = 0; i < n && s.conn != nil; i++ {
 		buf := batch[i]
-		// todo: can we just send all the batches in one call? for tcp we might just be able to seperate with \n for and let `_, err := buf.WriteTo(s.conn)` write all at once... they should already be seperated this way looking at netSink.Flush*
+		// todo: can we just send all the batches in one call? for tcp we might just be able to separate with \n for and let `_, err := buf.WriteTo(s.conn)` write all at once... they should already be separated this way looking at netSink.Flush*
 		if err := s.send(&buf); err == nil {
 			putBuffer(&buf)
 		}

--- a/net_sink.go
+++ b/net_sink.go
@@ -274,11 +274,14 @@ func (s *netSink) FlushTimer(name string, value float64) {
 
 func (s *netSink) run() {
 	addr := net.JoinHostPort(s.conf.StatsdHost, strconv.Itoa(s.conf.StatsdPort))
+	delayedFlush := GetSettings().DelayedFlush
 
 	var reconnectFailed bool // true if last reconnect failed
 
 	t := time.NewTicker(flushInterval)
 	defer t.Stop()
+
+	// metric write loop (actively draining content of outc channel)
 	for {
 		if s.conn == nil {
 			if err := s.connect(addr); err != nil {
@@ -312,9 +315,11 @@ func (s *netSink) run() {
 			// Drop through in case retryc has nothing.
 		}
 
+		if len(s.outc) == cap(s.outc) {
+			s.Flush()
+		}
+
 		select {
-		case <-t.C:
-			s.flush()
 		case done := <-s.doFlush:
 			// Only flush pending buffers, this prevents an issue where
 			// continuous writes prevent the flush loop from exiting.
@@ -332,7 +337,15 @@ func (s *netSink) run() {
 				putBuffer(buf)
 			}
 			close(done)
+		case <-t.C:
+			s.flush()
 		case buf := <-s.outc:
+			// naturally we will write anytime ve data here. since timers are actively/adhoc written to outc there is no batching or flush control (gauages and counters only write data to outc at a cadence of GOSTATS_FLUSH_INTERVAL_SECONDS)
+			// by skipping this we move ourselves to just relying on doFlush which is also controlled by the GOSTATS_FLUSH_INTERVAL_SECONDS ticker
+			// maybe delaying gauges and counters writes by a second, but importantly implying timer writes at an interval, not just whenever
+			if delayedFlush {
+				continue
+			}
 			if err := s.writeToConn(buf); err != nil {
 				s.retryc <- buf
 				continue

--- a/net_sink.go
+++ b/net_sink.go
@@ -118,8 +118,8 @@ func NewNetSink(opts ...SinkOption) FlushableSink {
 		bufSize = defaultBufferSizeTCP
 	}
 
-	s.outc = make(chan *bytes.Buffer, approxMaxMemBytes/bufSize)
-	s.retryc = make(chan *bytes.Buffer, 1) // It should be okay to limit this given we preferentially process from this over outc.
+	s.outc = make(chan *bytes.Buffer, approxMaxMemBytes/bufSize) // todo: need to understand why/how this number was chosen and probably elevate it
+	s.retryc = make(chan *bytes.Buffer, 1)                       // It should be okay to limit this given we preferentially process from this over outc.
 
 	writer := &sinkWriter{outc: s.outc}
 	s.bufWriter = bufio.NewWriterSize(writer, bufSize)

--- a/net_sink.go
+++ b/net_sink.go
@@ -109,8 +109,7 @@ func NewNetSink(opts ...SinkOption) FlushableSink {
 	}
 
 	// Calculate buffer size based on protocol, for UDP we want to pick a
-	// buffer size that will prevent datagram fragmentation.
-	// todo: for batching does the batch size need to be a multiple of the buffer size to prevent fragmentation?
+	// buffer size that will prevent datagram fragmentation of a single stat.
 	var bufSize int
 	switch s.conf.StatsdProtocol {
 	case "udp", "udp4", "udp6":
@@ -119,8 +118,8 @@ func NewNetSink(opts ...SinkOption) FlushableSink {
 		bufSize = defaultBufferSizeTCP
 	}
 
-	s.outc = make(chan *bytes.Buffer, approxMaxMemBytes/bufSize)
-	s.retryc = make(chan *bytes.Buffer, 1) // It should be okay to limit this given once we write to the retry channel we break the connection, and in subsequent processing we preferentially process from this over outc.
+	s.outc = make(chan *bytes.Buffer, approxMaxMemBytes/bufSize) // this will reduce the maximum number stats we send when draining/sending pending buffers (doFlush) but won't limit batched sends in the same way
+	s.retryc = make(chan *bytes.Buffer, 1)                       // It should be okay to limit this given once we write to the retry channel we break the connection, and in subsequent processing we preferentially process from this over outc.
 
 	writer := &sinkWriter{outc: s.outc}
 	s.bufWriter = bufio.NewWriterSize(writer, bufSize)
@@ -279,14 +278,15 @@ func (s *netSink) run() {
 
 	var reconnectFailed bool // true if last reconnect failed
 
-	settings := GetSettings()
+	isBatchEnabled := s.conf.BatchEnabled
 
-	batchSize := settings.BatchSize
-	isBatchEnabled := batchSize > 0
-	batch := make([]bytes.Buffer, 0, batchSize+cap(s.outc)) // overallocate to consider draining all outc data. despite the expanded allocation, batchSize is still used to determine if we send the batched stats
-	sendBatch := false
-	batchTimeout := time.Duration(settings.FlushIntervalS) * time.Second // todo: is there any need to use a new configuration for this?
+	batchSize := s.conf.BatchSize
+	batch := make([]bytes.Buffer, 0, batchSize+cap(s.outc)) // overallocate to consider draining outstanding outc data. despite the expanded allocation, batchSize is still used to determine if we send the batched stats
+
+	batchTimeout := time.Duration(s.conf.BatchSendIntervalS) * time.Second
 	batchInterval := time.After(batchTimeout)
+
+	sendBatch := false
 
 	t := time.NewTicker(flushInterval)
 	defer t.Stop()

--- a/net_sink.go
+++ b/net_sink.go
@@ -118,7 +118,7 @@ func NewNetSink(opts ...SinkOption) FlushableSink {
 		bufSize = defaultBufferSizeTCP
 	}
 
-	s.outc = make(chan *bytes.Buffer, approxMaxMemBytes/bufSize) // todo: this computes to a buffer of 2928 for udp and 64 for tcp do we need to influence batch size based on this?
+	s.outc = make(chan *bytes.Buffer, approxMaxMemBytes/bufSize) // todo: this creates a channel with a buffer of 2928 for udp and 64 for tcp do we need to influence batch size based on this?
 	s.retryc = make(chan *bytes.Buffer, 1)                       // It should be okay to limit this given we preferentially process from this over outc.
 
 	writer := &sinkWriter{outc: s.outc}
@@ -157,12 +157,12 @@ func (w *sinkWriter) Write(p []byte) (int, error) {
 }
 
 func (s *netSink) Flush() {
-	// flushed buffer to outc which will write immediately
+	// forcefully flush the buffer to outc which will send immediately if batching is disabled
 	if s.flush() != nil {
 		return // nothing we can do
 	}
 	ch := make(chan struct{})
-	s.doFlush <- ch // send batches
+	s.doFlush <- ch // send collected outc batches
 	<-ch
 }
 
@@ -319,7 +319,7 @@ func (s *netSink) run() {
 			// Drop through in case retryc has nothing.
 		}
 
-		// send batch if full
+		// send batched outc data anytime we're full and can't batch anymore
 		if len(batch) == cap(batch) {
 			batch = s.sendBatch(batch)
 		}
@@ -327,21 +327,21 @@ func (s *netSink) run() {
 		// flush to outc and batch and/or send outc
 		select {
 		case done := <-s.doFlush:
-			// send batch on doFlush signal
+			// send batched outc data
 			batch = s.sendBatch(batch)
 			close(done)
 		case buf := <-s.outc:
 			if isBatchEnabled {
-				// Batch outc data rely on doFlush signal to send
+				// batch outc data and rely on the doFlush or max capacity to send
 				batch = append(batch, *buf)
 				continue
 			}
-			// Without batching we will send stats if outc has data
+			// send outc data immediately
 			if err := s.send(buf); err == nil {
 				putBuffer(buf)
 			}
 		case <-t.C:
-			s.flush() // from a higher level, stats write to s.bufWriter at GOSTATS_FLUSH_INTERVAL_SECONDS (or adhoc for Timers). this flushes them to outc every t.C tick
+			s.flush() // from a higher level, stats are written to s.bufWriter.buf at GOSTATS_FLUSH_INTERVAL_SECONDS (or adhoc for Timers). this flushes them to outc every t.C tick
 		}
 	}
 }

--- a/net_sink.go
+++ b/net_sink.go
@@ -110,6 +110,7 @@ func NewNetSink(opts ...SinkOption) FlushableSink {
 
 	// Calculate buffer size based on protocol, for UDP we want to pick a
 	// buffer size that will prevent datagram fragmentation.
+	// todo: for batching does the batch size need to be a multiple of the buffer size to prevent fragmentation?
 	var bufSize int
 	switch s.conf.StatsdProtocol {
 	case "udp", "udp4", "udp6":
@@ -118,8 +119,8 @@ func NewNetSink(opts ...SinkOption) FlushableSink {
 		bufSize = defaultBufferSizeTCP
 	}
 
-	s.outc = make(chan *bytes.Buffer, approxMaxMemBytes/bufSize) // todo: this creates a channel with a buffer of 2928 for udp and 64 for tcp do we need to influence batch size based on this?
-	s.retryc = make(chan *bytes.Buffer, 1)                       // It should be okay to limit this given once we write to the retry channel we break the connection, and in subsequent processing we preferentially process from this over outc.
+	s.outc = make(chan *bytes.Buffer, approxMaxMemBytes/bufSize)
+	s.retryc = make(chan *bytes.Buffer, 1) // It should be okay to limit this given once we write to the retry channel we break the connection, and in subsequent processing we preferentially process from this over outc.
 
 	writer := &sinkWriter{outc: s.outc}
 	s.bufWriter = bufio.NewWriterSize(writer, bufSize)
@@ -156,13 +157,13 @@ func (w *sinkWriter) Write(p []byte) (int, error) {
 	}
 }
 
+// flush the entire buffer to outc and drain it, either sending directly or batching
 func (s *netSink) Flush() {
-	// forcefully flush the buffer to outc which will start sending immediately if batching is disabled
 	if s.flush() != nil {
 		return // nothing we can do
 	}
 	ch := make(chan struct{})
-	s.doFlush <- ch // send collected outc batches and anything pre-batched in outc
+	s.doFlush <- ch
 	<-ch
 }
 
@@ -284,16 +285,19 @@ func (s *netSink) run() {
 	isBatchEnabled := batchSize > 0
 	batch := make([]bytes.Buffer, 0, batchSize+cap(s.outc)) // expand allocation to allow for draining outc. todo change to an array to optimize
 	sendBatch := false
-	batchTimeout := time.Duration(settings.FlushIntervalS) * time.Second // todo maybe use a new configuration for batch flush interval
+	batchTimeout := time.Duration(settings.FlushIntervalS) * time.Second // todo: is there any need to use a new configuration for this?
 	batchInterval := time.After(batchTimeout)
 
 	t := time.NewTicker(flushInterval)
 	defer t.Stop()
 
-	// flush all/any buffered stats (on specified ticker) and send loop
+	// outc send loop (if batching is enabled, send every batchTimeout, if indicated by doFlush, or if the batch is full)
+	// auto-flushes any/all buffered stats (on specified ticker) to outc
 	for {
 		// writeToConn will set s.conn to nil on error, try to reconnect
 		if s.conn == nil {
+			// connect to statsd server
+			// the connection will be persisted unless an error occurs. thereby with batching is used the entire batch will be streamed under 1 connection
 			if err := s.connect(addr); err != nil {
 				s.log.Warnf("connection error: %s", err)
 
@@ -311,7 +315,7 @@ func (s *netSink) run() {
 			reconnectFailed = false
 		}
 
-		// Drain all retries first
+		// Drain all retries first and continue loop if there are multiple things to retry
 		select {
 		case buf := <-s.retryc:
 			if err := s.writeToConn(buf); err != nil {
@@ -320,7 +324,7 @@ func (s *netSink) run() {
 				s.mu.Unlock()
 			}
 			putBuffer(buf)
-			continue // if error we may need to reconnect so go back to the top of the next itteration and maybe there's more to retry, continue loop to clear all retries first
+			continue // if error we may need to reconnect so go back to the top of the next iteration
 		default:
 			// Drop through in case retryc has nothing.
 		}
@@ -330,17 +334,18 @@ func (s *netSink) run() {
 			var err error
 			batch, err = s.sendBatch(batch)
 			if err != nil {
-				sendBatch = true // guarantee for all cases that we complete sending the batch after retrying and before procecessing anything else
-				continue         // cut the iteration to process retries (nothing can be sent anyway since writeToConn failure with set s.conn to nil)
+				sendBatch = true // indicate to continue sending out the batch in the next iterration if any erros occur (needed if entering from len(batch) >= batchSize)
+				continue         // cut the iteration to process retry (s.conn will be nil anyway)
 			}
 			sendBatch = false
 			batchInterval = time.After(batchTimeout)
 		}
 
-		// flush buffer to outc and batch and/or send outc
 		select {
-		case <-t.C: // todo: should this not be the last case? if outc is at cap don't we risk blocking if we don't prioritizing reading/draining it? or just do some precalculation and error in the flush for this case?
-			s.flush() // from a higher level, stats are written to s.bufWriter.buf at GOSTATS_FLUSH_INTERVAL_SECONDS (or adhoc for Timers). this flushes them to outc every t.C tick
+		// flush buffer to outc
+		// from a higher level, stats are written to s.bufWriter.buf at GOSTATS_FLUSH_INTERVAL_SECONDS (or adhoc for Timers). this flushes them to outc every t.C tick
+		case <-t.C:
+			s.flush() // todo: if outc is at cap don't we risk blocking if we don't prioritizing reading it or would the flush error out?
 
 			select {
 			case <-batchInterval:
@@ -349,18 +354,16 @@ func (s *netSink) run() {
 				}
 			default:
 			}
+		// drain all outc data. either batch or send immediatedly
 		case done := <-s.doFlush:
 			if isBatchEnabled {
-				n := len(s.outc)                          // Only flush pending buffers, this prevents an issue where continuous writes prevent the flush loop from exiting.
-				for i := 0; i < n && s.conn != nil; i++ { // todo: this can cause batch to exceed allocation if current cap(batch) is small, if cap(batch) - len(batch) is less than the len(s.outc) we are draining
+				n := len(s.outc)
+				for i := 0; i < n && s.conn != nil; i++ {
 					buf := <-s.outc
-					batch = append(batch, *buf)
+					batch = append(batch, *buf) // todo: we may exceed allocation here if if current cap(batch) is small, if cap(batch) - len(batch) is less than the len(s.outc) we are draining
 				}
-				// indicate batched outc data to be sent in the next iteration
-				sendBatch = true
+				sendBatch = true // indicate batched outc data to be sent in the next iteration
 			} else {
-				// drain and send remaining outc data
-				// todo re-evaluate: this code is probably redundant, outc should naturally become empty with `case buf := <-s.outc`, why is a forced drain required?
 				n := len(s.outc) // Only flush pending buffers, this prevents an issue where continuous writes prevent the flush loop from exiting.
 				for i := 0; i < n && s.conn != nil; i++ {
 					buf := <-s.outc
@@ -372,14 +375,13 @@ func (s *netSink) run() {
 			}
 
 			close(done)
+		// drain one stat from outc if avaible. either batch or send immediatedly
 		case buf := <-s.outc:
 			if isBatchEnabled {
-				// batch outc data and rely on the doFlush or max capacity to send
 				batch = append(batch, *buf)
 				continue
 			}
 
-			// send outc data immediately
 			if err := s.send(buf); err == nil {
 				putBuffer(buf)
 			}
@@ -401,7 +403,6 @@ func (s *netSink) sendBatch(batch []bytes.Buffer) ([]bytes.Buffer, error) {
 	var i int
 	for i = 0; i < n && s.conn != nil; i++ {
 		buf := batch[i]
-		// todo: can we just send all the batches in one call? for tcp we might just be able to separate with \n for and let `_, err := buf.WriteTo(s.conn)` write all at once... they should already be separated this way looking at netSink.Flush*
 		if err := s.send(&buf); err == nil {
 			putBuffer(&buf)
 		}
@@ -410,11 +411,11 @@ func (s *netSink) sendBatch(batch []bytes.Buffer) ([]bytes.Buffer, error) {
 
 	var err error
 	if i != n {
-		i++                                                              // the current element is in and will be processed over the retry channel
+		i++                                                              // the current element will be processed over the retry channel so assume it processed from the batch
 		err = fmt.Errorf("batch send failure, only sent %d of %d", i, n) // todo log this
 	}
 
-	return batch[i:n:n], err // return items in batch which we haven't sent. todo make sure the data in retryc is not duplicated in our response batch, otherwise we may infinite loop
+	return batch[i:n:n], err // return items in batch which we haven't sent. todo: make sure the data in retryc is not duplicated in our response batch, otherwise we may infinite loop
 }
 
 // writeToConn writes the buffer to the underlying conn.  May only be called

--- a/net_sink.go
+++ b/net_sink.go
@@ -278,26 +278,32 @@ func (s *netSink) run() {
 
 	var reconnectFailed bool // true if last reconnect failed
 
-	isBatchEnabled := s.conf.BatchEnabled
-
-	batchSize := s.conf.BatchSize
-	batch := make([]bytes.Buffer, 0, batchSize+cap(s.outc)) // overallocate to consider draining outstanding outc data. despite the expanded allocation, batchSize is still used to determine if we send the batched stats
-
-	batchTimeout := time.Duration(s.conf.BatchSendIntervalS) * time.Second
-	batchInterval := time.After(batchTimeout)
-
-	doSendBatch := false
-
 	t := time.NewTicker(flushInterval)
 	defer t.Stop()
 
-	// outc send loop (if batching is enabled, send every batchTimeout, if indicated by doFlush, or if the batch is full)
+	isBatchEnabled := s.conf.BatchEnabled
+
+	batchSize := s.conf.BatchSize
+	batch := make([]bytes.Buffer, 0, batchSize+cap(s.outc)) // overallocate to consider draining outstanding outc data
+	var batchInterval *time.Ticker
+	var doSendBatch bool
+
+	if isBatchEnabled {
+		batchInterval = time.NewTicker(time.Duration(s.conf.BatchSendIntervalS) * time.Second)
+		defer batchInterval.Stop()
+	}
+
+	// outc send loop
 	// auto-flushes any/all buffered stats (on specified ticker) to outc
+	// with batching: sends every batchInterval or if the batch is full
+	// without batching: send anytime outc data and/or indicated by doFlush
 	for {
+		doSendBatch = doSendBatch || (isBatchEnabled && len(batch) >= batchSize)
+
 		// writeToConn will set s.conn to nil on error, try to reconnect
 		if s.conn == nil {
 			// connect to statsd server
-			// the connection will be persisted unless an error occurs. thereby when batching is used the entire batch will be streamed under 1 connection
+			// the connection will be persisted unless an error occurs. when batching is used the entire batch should be streamed under 1 connection
 			if err := s.connect(addr); err != nil {
 				s.log.Warnf("connection error: %s", err)
 
@@ -330,63 +336,58 @@ func (s *netSink) run() {
 		}
 
 		// send batched outc data anytime indicated or the batch is full
-		if doSendBatch || len(batch) >= batchSize {
+		if doSendBatch {
 			var err error
 			batch, err = s.sendBatch(batch)
 			if err != nil {
-				doSendBatch = true // indicate to continue sending out the batch in the next iterration if any erros occur (needed if entering from len(batch) >= batchSize)
-				continue           // cut the iteration to process retry (s.conn will be nil anyway)
+				continue // cut the iteration to process retry (s.conn will be nil anyway). doSendBatch will still be true
 			}
 			doSendBatch = false
-			batchInterval = time.After(batchTimeout)
 		}
 
 		select {
 		// flush buffer to outc
 		// from a higher level, stats are written to s.bufWriter.buf at GOSTATS_FLUSH_INTERVAL_SECONDS (or adhoc for Timers). this flushes them to outc every t.C tick
+		// with batching: additionallity check if the we have anything to send in the batch interval
 		case <-t.C:
 			s.flush() // if outc is or becomes full the sinkWriter will error and we will gracefully drop the remainding buffered stats
 
-			select {
-			case <-batchInterval:
-				if len(batch) > 0 {
-					doSendBatch = true
-				} else {
-					batchInterval = time.After(batchTimeout)
-				}
-			default:
-				// No need to block here, drop through check again in the next t.C interval
-			}
-		// drain all outc data. either batch or send immediatedly
-		case done := <-s.doFlush:
 			if isBatchEnabled {
-				n := len(s.outc)
+				select {
+				case <-batchInterval.C:
+					doSendBatch = len(batch) > 0
+				default:
+					// No need to block here, drop through check again in the next t.C interval
+				}
+			}
+		// drain all outc data
+		case done := <-s.doFlush:
+			n := len(s.outc) // Only flush pending buffers, this prevents an issue where continuous writes prevent the flush loop from exiting.
+
+			if isBatchEnabled {
 				for i := 0; i < n && s.conn != nil; i++ {
 					buf := <-s.outc
 					batch = append(batch, *buf)
 				}
-				doSendBatch = true // indicate batched outc data to be sent in the next iteration
 			} else {
-				n := len(s.outc) // Only flush pending buffers, this prevents an issue where continuous writes prevent the flush loop from exiting.
 				for i := 0; i < n && s.conn != nil; i++ {
 					buf := <-s.outc
 					if err := s.send(buf); err == nil {
 						putBuffer(buf)
 					}
-					// if an error occurs we send the metric to the retry channel and make s.conn nil, breaking this loop and preventing further batch processing in this stack
+					// if an error occurs we send the metric to the retry channel and make s.conn nil, breaking this loop
 				}
 			}
 
 			close(done)
-		// drain one stat from outc if avaible. either batch or send immediatedly
+		// drain one stat from outc if avaible
 		case buf := <-s.outc:
 			if isBatchEnabled {
 				batch = append(batch, *buf)
-				continue
-			}
-
-			if err := s.send(buf); err == nil {
-				putBuffer(buf)
+			} else {
+				if err := s.send(buf); err == nil {
+					putBuffer(buf)
+				}
 			}
 		}
 	}
@@ -417,7 +418,7 @@ func (s *netSink) sendBatch(batch []bytes.Buffer) ([]bytes.Buffer, error) {
 		err = fmt.Errorf("batch send failure, only sent %d of %d", i, n)
 	}
 
-	return batch[i:n:n], err
+	return batch[i:n:cap(batch)], err
 }
 
 // writeToConn writes the buffer to the underlying conn.  May only be called

--- a/net_sink.go
+++ b/net_sink.go
@@ -281,25 +281,29 @@ func (s *netSink) run() {
 	t := time.NewTicker(flushInterval)
 	defer t.Stop()
 
-	isBatchEnabled := s.conf.BatchEnabled
+	var sender sender
 
-	batchSize := s.conf.BatchSize
-	batch := make([]bytes.Buffer, 0, batchSize+cap(s.outc)) // overallocate to consider draining outstanding outc data
-	var batchInterval *time.Ticker
-	var doSendBatch bool
-
-	if isBatchEnabled {
-		batchInterval = time.NewTicker(time.Duration(s.conf.BatchSendIntervalS) * time.Second)
+	if s.conf.BatchEnabled {
+		batchInterval := time.NewTicker(time.Duration(s.conf.BatchSendIntervalS) * time.Second)
+		batchSize := s.conf.BatchSize
+		// send every batchInterval or if the batch is full
+		sender = &batchSender{
+			sink:          s,
+			batch:         make([]bytes.Buffer, 0, batchSize+cap(s.outc)), // overallocate to consider draining outstanding outc data
+			batchSize:     batchSize,
+			batchInterval: batchInterval,
+			doSendBatch:   false,
+		}
 		defer batchInterval.Stop()
+
+	} else {
+		// send anytime outc data and/or indicated by doFlush
+		sender = &genericSender{sink: s}
 	}
 
 	// outc send loop
 	// auto-flushes any/all buffered stats (on specified ticker) to outc
-	// with batching: sends every batchInterval or if the batch is full
-	// without batching: send anytime outc data and/or indicated by doFlush
 	for {
-		doSendBatch = doSendBatch || (isBatchEnabled && len(batch) >= batchSize)
-
 		// writeToConn will set s.conn to nil on error, try to reconnect
 		if s.conn == nil {
 			// connect to statsd server
@@ -335,61 +339,26 @@ func (s *netSink) run() {
 			// Drop through in case retryc has nothing.
 		}
 
-		// send batched outc data anytime indicated or the batch is full
-		if doSendBatch {
-			var err error
-			batch, err = s.sendBatch(batch)
-			if err != nil {
-				continue // cut the iteration to process retry (s.conn will be nil anyway). doSendBatch will still be true
-			}
-			doSendBatch = false
+		// for non-batching: always nil using genericSender
+		if err := sender.processBatch(); err != nil {
+			continue // if we're here assume an error occured and the batch hasn't finished sending, in this case s.conn is probably nil and we have a stat to retry. cut the iteration to the top
 		}
 
 		select {
 		// flush buffer to outc
 		// from a higher level, stats are written to s.bufWriter.buf at GOSTATS_FLUSH_INTERVAL_SECONDS (or adhoc for Timers). this flushes them to outc every t.C tick
-		// with batching: additionallity check if the we have anything to send in the batch interval
+		// for batching: also check if we want to send the batch
 		case <-t.C:
 			s.flush() // if outc is or becomes full the sinkWriter will error and we will gracefully drop the remainding buffered stats
-
-			if isBatchEnabled {
-				select {
-				case <-batchInterval.C:
-					doSendBatch = len(batch) > 0
-				default:
-					// No need to block here, drop through check again in the next t.C interval
-				}
-			}
-		// drain all outc data
+			sender.scheduleBatch()
 		case done := <-s.doFlush:
 			n := len(s.outc) // Only flush pending buffers, this prevents an issue where continuous writes prevent the flush loop from exiting.
-
-			if isBatchEnabled {
-				for i := 0; i < n && s.conn != nil; i++ {
-					buf := <-s.outc
-					batch = append(batch, *buf)
-				}
-			} else {
-				for i := 0; i < n && s.conn != nil; i++ {
-					buf := <-s.outc
-					if err := s.send(buf); err == nil {
-						putBuffer(buf)
-					}
-					// if an error occurs we send the metric to the retry channel and make s.conn nil, breaking this loop
-				}
-			}
-
+			sender.processBuffersThroughChannel(n, s.outc)
 			close(done)
-		// drain one stat from outc if avaible
 		case buf := <-s.outc:
-			if isBatchEnabled {
-				batch = append(batch, *buf)
-			} else {
-				if err := s.send(buf); err == nil {
-					putBuffer(buf)
-				}
-			}
+			sender.processBuffer(buf)
 		}
+
 	}
 }
 
@@ -443,6 +412,83 @@ func (s *netSink) connect(address string) error {
 		s.conn = conn
 	}
 	return err
+}
+
+type sender interface {
+	processBatch() error
+	scheduleBatch()
+	processBuffersThroughChannel(int, <-chan *bytes.Buffer)
+	processBuffer(*bytes.Buffer)
+}
+
+type genericSender struct {
+	sink *netSink
+}
+
+func (gs *genericSender) processBatch() error {
+	return nil
+}
+
+func (gs *genericSender) scheduleBatch() {}
+
+func (gs *genericSender) processBuffersThroughChannel(n int, outc <-chan *bytes.Buffer) {
+	// drain all outc data and send
+	for i := 0; i < n && gs.sink.conn != nil; i++ {
+		buf := <-outc
+		if err := gs.sink.send(buf); err == nil {
+			putBuffer(buf)
+		}
+		// if an error occurs we send the metric to the retry channel and make s.conn nil, breaking this loop
+	}
+}
+
+func (gs *genericSender) processBuffer(buf *bytes.Buffer) {
+	// send stat
+	if err := gs.sink.send(buf); err == nil {
+		putBuffer(buf)
+	}
+}
+
+type batchSender struct {
+	sink          *netSink
+	batch         []bytes.Buffer
+	batchSize     int
+	batchInterval *time.Ticker
+	doSendBatch   bool
+}
+
+func (bs *batchSender) processBatch() error {
+	var err error
+
+	// send batched outc data anytime indicated or the batch is full
+	if bs.doSendBatch = bs.doSendBatch || len(bs.batch) >= bs.batchSize; bs.doSendBatch {
+		bs.batch, err = bs.sink.sendBatch(bs.batch)
+		bs.doSendBatch = err == nil
+	}
+
+	return err
+}
+
+func (bs *batchSender) scheduleBatch() {
+	select {
+	case <-bs.batchInterval.C:
+		bs.doSendBatch = len(bs.batch) > 0
+	default:
+		// No need to block here, drop through check again when called in the future
+	}
+}
+
+func (bs *batchSender) processBuffersThroughChannel(n int, outc <-chan *bytes.Buffer) {
+	// drain all outc data to batch
+	for i := 0; i < n; i++ {
+		buf := <-outc
+		bs.batch = append(bs.batch, *buf)
+	}
+}
+
+func (bs *batchSender) processBuffer(buf *bytes.Buffer) {
+	// add stat to batch
+	bs.batch = append(bs.batch, *buf)
 }
 
 var bufferPool sync.Pool

--- a/net_sink.go
+++ b/net_sink.go
@@ -278,12 +278,15 @@ func (s *netSink) run() {
 
 	var reconnectFailed bool // true if last reconnect failed
 
-	batchSize := GetSettings().BatchSize
+	settings := GetSettings()
+
+	batchSize := settings.BatchSize
 	isBatchEnabled := batchSize > 0
 	batch := make([]bytes.Buffer, 0, batchSize+cap(s.outc)) // expand allocation to allow for draining outc. todo change to an array to optimize
 	sendBatch := false
 
 	t := time.NewTicker(flushInterval)
+	bt := time.NewTicker(time.Duration(settings.FlushIntervalS) * time.Second) // todo maybe use a new configuration for batch flush interval
 	defer t.Stop()
 
 	// flush all/any buffered stats (on specified ticker) and send loop
@@ -322,11 +325,11 @@ func (s *netSink) run() {
 		}
 
 		// send batched outc data anytime indicated or the batch is full
-		if sendBatch || len(batch) == batchSize {
+		if sendBatch || len(batch) >= batchSize {
 			var err error
 			batch, err = s.sendBatch(batch)
 			if err != nil {
-				sendBatch = true // guarantee we conitnue to complete sending the batch after retrying and before procecessing anything else
+				sendBatch = true // guarentee for all cases that we complete sending the batch after retrying and before procecessing anything else
 				continue         // cut the iteration to process retries (nothing can be sent anyway since writeToConn failure with set s.conn to nil)
 			}
 			sendBatch = false
@@ -356,6 +359,7 @@ func (s *netSink) run() {
 				if err := s.send(buf); err == nil {
 					putBuffer(buf)
 				}
+				// if an error occurs we send the metric to the retry channel and make s.conn nil, breaking this loop and preventing further batch processing in this stack
 			}
 
 			close(done)
@@ -372,6 +376,11 @@ func (s *netSink) run() {
 			}
 		}
 
+		select {
+		case <-bt.C:
+			sendBatch = true
+		default:
+		}
 	}
 }
 

--- a/net_sink.go
+++ b/net_sink.go
@@ -276,8 +276,6 @@ func (s *netSink) FlushTimer(name string, value float64) {
 func (s *netSink) run() {
 	addr := net.JoinHostPort(s.conf.StatsdHost, strconv.Itoa(s.conf.StatsdPort))
 
-	var reconnectFailed bool // true if last reconnect failed
-
 	t := time.NewTicker(flushInterval)
 	defer t.Stop()
 
@@ -288,7 +286,11 @@ func (s *netSink) run() {
 		batchSize := s.conf.BatchSize
 		// send every batchInterval or if the batch is full
 		sender = &batchSender{
-			sink:          s,
+			genericSender: genericSender{
+				sink:            s,
+				address:         addr,
+				reconnectFailed: false,
+			},
 			batch:         make([]bytes.Buffer, 0, batchSize+cap(s.outc)), // overallocate to consider draining outstanding outc data
 			batchSize:     batchSize,
 			batchInterval: batchInterval,
@@ -298,50 +300,25 @@ func (s *netSink) run() {
 
 	} else {
 		// send anytime outc data and/or indicated by doFlush
-		sender = &genericSender{sink: s}
+		sender = &genericSender{
+			sink:            s,
+			address:         addr,
+			reconnectFailed: false,
+		}
 	}
 
 	// outc send loop
 	// auto-flushes any/all buffered stats (on specified ticker) to outc
 	for {
-		// writeToConn will set s.conn to nil on error, try to reconnect
-		if s.conn == nil {
-			// connect to statsd server
-			// the connection will be persisted unless an error occurs. when batching is used the entire batch should be streamed under 1 connection
-			if err := s.connect(addr); err != nil {
-				s.log.Warnf("connection error: %s", err)
-
-				// If the previous reconnect attempt failed, drain the flush
-				// queue to prevent Flush() from blocking indefinitely.
-				if reconnectFailed {
-					s.drainFlushQueue()
-				}
-				reconnectFailed = true
-
+		// during init we should create a connection and process retries, when batching is used the entire batch should be streamed under 1 connection
+		// additionally for batching: send the batch if needed
+		if connected, err := sender.init(); err != nil {
+			// if we're here assume an error occurred, in this case s.conn is probably nil and we have a stat to retry. cut the iteration to the top and try again
+			if !connected {
 				// TODO (CEV): don't sleep on the first retry
 				time.Sleep(defaultRetryInterval)
-				continue
 			}
-			reconnectFailed = false
-		}
-
-		// Drain all retries first and continue loop if there are multiple things to retry
-		select {
-		case buf := <-s.retryc:
-			if err := s.writeToConn(buf); err != nil {
-				s.mu.Lock()
-				s.handleFlushErrorSize(err, buf.Len())
-				s.mu.Unlock()
-			}
-			putBuffer(buf)
-			continue // we will need to reconnect if an error occurs, so go back to the top of the next iteration to see
-		default:
-			// Drop through in case retryc has nothing.
-		}
-
-		// for non-batching: always nil using genericSender
-		if err := sender.processBatch(); err != nil {
-			continue // if we're here assume an error occurred and the batch hasn't finished sending, in this case s.conn is probably nil and we have a stat to retry. cut the iteration to the top
+			continue
 		}
 
 		select {
@@ -350,7 +327,7 @@ func (s *netSink) run() {
 		// for batching: also check if we want to send the batch
 		case <-t.C:
 			s.flush() // if outc is or becomes full the sinkWriter will error and we will gracefully drop the remainding buffered stats
-			sender.scheduleBatch()
+			sender.scheduleSend()
 		case done := <-s.doFlush:
 			n := len(s.outc) // Only flush pending buffers, this prevents an issue where continuous writes prevent the flush loop from exiting.
 			sender.processBuffersThroughChannel(n, s.outc)
@@ -400,7 +377,7 @@ func (s *netSink) writeToConn(buf *bytes.Buffer) error {
 
 	if err != nil {
 		_ = s.conn.Close()
-		s.conn = nil // this will break the loop
+		s.conn = nil
 	}
 	return err
 }
@@ -415,21 +392,43 @@ func (s *netSink) connect(address string) error {
 }
 
 type sender interface {
-	processBatch() error
-	scheduleBatch()
+	init() (bool, error)
+	scheduleSend()
 	processBuffersThroughChannel(int, <-chan *bytes.Buffer)
 	processBuffer(*bytes.Buffer)
 }
 
 type genericSender struct {
-	sink *netSink
+	sink            *netSink
+	address         string
+	reconnectFailed bool
 }
 
-func (gs *genericSender) processBatch() error {
-	return nil
+func (gs *genericSender) init() (bool, error) {
+	// upon error s.conn should become nil, try to reconnect if needed
+	if err := connectSender(gs.sink, gs.address, gs.reconnectFailed); err != nil {
+		gs.reconnectFailed = true
+		return false, err
+	}
+
+	select {
+	case buf := <-gs.sink.retryc:
+		var err error
+		if err = gs.sink.writeToConn(buf); err != nil {
+			gs.sink.mu.Lock()
+			gs.sink.handleFlushErrorSize(err, buf.Len())
+			gs.sink.mu.Unlock()
+		}
+		putBuffer(buf)
+		return true, err // return with error to be called again to drain all retires
+	default:
+		// Drop through in case retryc has nothing.
+	}
+
+	return true, nil
 }
 
-func (gs *genericSender) scheduleBatch() {}
+func (gs *genericSender) scheduleSend() {}
 
 func (gs *genericSender) processBuffersThroughChannel(n int, outc <-chan *bytes.Buffer) {
 	// drain all outc data and send
@@ -450,26 +449,51 @@ func (gs *genericSender) processBuffer(buf *bytes.Buffer) {
 }
 
 type batchSender struct {
-	sink          *netSink
+	genericSender
 	batch         []bytes.Buffer
 	batchSize     int
 	batchInterval *time.Ticker
 	doSendBatch   bool
 }
 
-func (bs *batchSender) processBatch() error {
-	var err error
+func (bs *batchSender) init() (bool, error) {
+	select {
+	case buf := <-bs.sink.retryc:
+		// upon error s.conn should become nil, try to reconnect if needed
+		if err := connectSender(bs.sink, bs.address, bs.reconnectFailed); err != nil {
+			bs.reconnectFailed = true
+			return false, err
+		}
 
+		var err error
+		if err = bs.sink.writeToConn(buf); err != nil {
+			bs.sink.mu.Lock()
+			bs.sink.handleFlushErrorSize(err, buf.Len())
+			bs.sink.mu.Unlock()
+		}
+		putBuffer(buf)
+		return true, err // return with error to be called again to drain all retires
+	default:
+		// Drop through in case retryc has nothing.
+	}
+
+	var err error
 	// send batched outc data anytime indicated or the batch is full
 	if bs.doSendBatch = bs.doSendBatch || len(bs.batch) >= bs.batchSize; bs.doSendBatch {
+		// upon error s.conn should become nil, try to reconnect if needed
+		if err := connectSender(bs.sink, bs.address, bs.reconnectFailed); err != nil {
+			bs.reconnectFailed = true
+			return false, err
+		}
+
 		bs.batch, err = bs.sink.sendBatch(bs.batch)
 		bs.doSendBatch = err == nil
 	}
 
-	return err
+	return true, err
 }
 
-func (bs *batchSender) scheduleBatch() {
+func (bs *batchSender) scheduleSend() {
 	select {
 	case <-bs.batchInterval.C:
 		bs.doSendBatch = len(bs.batch) > 0
@@ -489,6 +513,26 @@ func (bs *batchSender) processBuffersThroughChannel(n int, outc <-chan *bytes.Bu
 func (bs *batchSender) processBuffer(buf *bytes.Buffer) {
 	// add stat to batch
 	bs.batch = append(bs.batch, *buf)
+}
+
+func connectSender(sink *netSink, address string, previousFailure bool) error {
+	if sink.conn == nil {
+		// connect to statsd server
+		// the connection will be persisted unless an error occurs
+		if err := sink.connect(address); err != nil {
+			sink.log.Warnf("connection error: %s", err)
+
+			// If the previous reconnect attempt failed, drain the flush
+			// queue to prevent Flush() from blocking indefinitely.
+			if previousFailure {
+				sink.drainFlushQueue()
+			}
+
+			return err
+		}
+	}
+
+	return nil
 }
 
 var bufferPool sync.Pool

--- a/net_sink.go
+++ b/net_sink.go
@@ -274,11 +274,11 @@ func (s *netSink) FlushTimer(name string, value float64) {
 
 func (s *netSink) run() {
 	addr := net.JoinHostPort(s.conf.StatsdHost, strconv.Itoa(s.conf.StatsdPort))
-	batch := GetSettings().ForcedBatching
-
-	batchc := make(chan *bytes.Buffer, cap(s.outc))
 
 	var reconnectFailed bool // true if last reconnect failed
+
+	batch := GetSettings().ForcedBatching
+	batches := make([]bytes.Buffer, 0, cap(s.outc)*4) // todo parameterize
 
 	t := time.NewTicker(flushInterval)
 	defer t.Stop()
@@ -317,26 +317,23 @@ func (s *netSink) run() {
 			// Drop through in case retryc has nothing.
 		}
 
-		// if the channel is at capacity, it's blocking, let's signal for it to be flushed and unblock
-		if len(s.outc) == cap(s.outc) {
-			s.Flush()
+		if len(batches) == cap(batches) {
+			s.doFlush <- make(chan struct{}) // todo in other writes to doFlush we block until the channel is closed, but since we're calling it from the same go routine we won't . it'll be better to factor to not rely on teh channel for all writes
 		}
 
 		select {
 		case done := <-s.doFlush:
-			n := len(batchc)
+			n := len(batches)
 			for i := 0; i < n && s.conn != nil; i++ {
-				buf := <-batchc
-				if err := s.writeToConn(buf); err != nil {
-					s.retryc <- buf
+				buf := batches[i]
+				if err := s.writeToConn(&buf); err != nil {
+					s.retryc <- &buf
 					continue
 				}
-				putBuffer(buf) // todo understand: we write the stats buffer we have successfully sent to a pool, but anytime we access data from that pool, we clear it and reuse the allocation for the next stat
+				putBuffer(&buf) // todo understand: we write the stats buffer we have successfully sent to a pool, but anytime we access data from that pool, we clear it and reuse the allocation for the next stat
 			}
-
+			batches = batches[:0]
 			close(done)
-		case <-t.C:
-			s.flush()
 		case buf := <-s.outc:
 			// Normally we will send stats anytime outc has data
 			//
@@ -349,7 +346,7 @@ func (s *netSink) run() {
 			// * Implied Timer batching under the flush interval
 			// * ~1 second delay to Gauge and Counter writes by batching these writes to the next internval
 			if batch {
-				batchc <- buf
+				batches = append(batches, *buf)
 				continue
 			}
 			if err := s.writeToConn(buf); err != nil {
@@ -357,6 +354,9 @@ func (s *netSink) run() {
 				continue
 			}
 			putBuffer(buf) // todo understand: we write the stats buffer we have successfully sent to a pool, but anytime we access data from that pool, we clear it and reuse the allocation for the next stat
+		case <-t.C:
+			// todo find out what happens if this channel is full
+			s.flush() // from a higher level, stats write to s.bufWriter at GOSTATS_FLUSH_INTERVAL_SECONDS (or adhoc for Timers). this flushes them to outc every t.C tick
 		}
 	}
 }

--- a/net_sink.go
+++ b/net_sink.go
@@ -326,7 +326,7 @@ func (s *netSink) run() {
 			var err error
 			batch, err = s.sendBatch(batch)
 			if err != nil {
-				sendBatch = true // guarentee we conitnue to complete sending the batch after retrying and before procecessing anything else
+				sendBatch = true // guarantee we conitnue to complete sending the batch after retrying and before procecessing anything else
 				continue         // cut the iteration to process retries (nothing can be sent anyway since writeToConn failure with set s.conn to nil)
 			}
 			sendBatch = false
@@ -388,7 +388,7 @@ func (s *netSink) sendBatch(batch []bytes.Buffer) ([]bytes.Buffer, error) {
 
 	var err error
 	if i != n {
-		i += 1 // the current element is in and will be processed over the retry channel
+		i++ // the current element is in and will be processed over the retry channel
 		err = fmt.Errorf("batch send failure, only sent %d of %d", i, n)
 	}
 

--- a/net_sink.go
+++ b/net_sink.go
@@ -274,7 +274,7 @@ func (s *netSink) FlushTimer(name string, value float64) {
 
 func (s *netSink) run() {
 	addr := net.JoinHostPort(s.conf.StatsdHost, strconv.Itoa(s.conf.StatsdPort))
-	delayedFlush := GetSettings().DelayedFlush
+	batch := GetSettings().ForcedBatching
 
 	var reconnectFailed bool // true if last reconnect failed
 
@@ -346,12 +346,12 @@ func (s *netSink) run() {
 			// Gauages and Counters are written to outc at a cadence of GOSTATS_FLUSH_INTERVAL_SECONDS
 			// Timers are written adhoc to outc
 			//
-			// With delayedFlush we will rely on doFlush which is also controlled by the GOSTATS_FLUSH_INTERVAL_SECONDS
+			// With batch we will rely on doFlush which is also controlled by the GOSTATS_FLUSH_INTERVAL_SECONDS
 			//
 			// Side effects:
 			// * Delayed Gauge and Counter writes by batching these at the end of the interval
 			// * Implied Timer batching and writing under the flush interval
-			if delayedFlush {
+			if batch {
 				continue
 			}
 			if err := s.writeToConn(buf); err != nil {

--- a/net_sink.go
+++ b/net_sink.go
@@ -318,7 +318,7 @@ func (s *netSink) run() {
 		}
 
 		if len(batches) == cap(batches) {
-			s.doFlush <- make(chan struct{}) // todo in other writes to doFlush we block until the channel is closed, but since we're calling it from the same go routine we won't . it'll be better to factor to not rely on teh channel for all writes
+			s.doFlush <- make(chan struct{}) // todo in other writes to doFlush we block until the channel is closed, but since we're calling it from the same go routine we won't . it'll be better to factor to not rely on the channel for all writes
 		}
 
 		select {

--- a/net_sink.go
+++ b/net_sink.go
@@ -311,7 +311,7 @@ func (s *netSink) run() {
 				s.handleFlushErrorSize(err, buf.Len())
 				s.mu.Unlock()
 			}
-			putBuffer(buf)
+			putBuffer(buf) // todo understand: we write the stats buffer we have successfully sent to a pool, but anytime we access data from that pool, we clear it and reuse the allocation for the next stat
 			continue
 		default:
 			// Drop through in case retryc has nothing.
@@ -331,7 +331,7 @@ func (s *netSink) run() {
 					s.retryc <- buf
 					continue
 				}
-				putBuffer(buf)
+				putBuffer(buf) // todo understand: we write the stats buffer we have successfully sent to a pool, but anytime we access data from that pool, we clear it and reuse the allocation for the next stat
 			}
 
 			close(done)
@@ -347,7 +347,7 @@ func (s *netSink) run() {
 			//
 			// Side effects:
 			// * Implied Timer batching under the flush interval
-			// * < 1 second delay to Gauge and Counter writes by batching these at the end of the interval
+			// * ~1 second delay to Gauge and Counter writes by batching these writes to the next internval
 			if batch {
 				batchc <- buf
 				continue
@@ -356,7 +356,7 @@ func (s *netSink) run() {
 				s.retryc <- buf
 				continue
 			}
-			putBuffer(buf)
+			putBuffer(buf) // todo understand: we write the stats buffer we have successfully sent to a pool, but anytime we access data from that pool, we clear it and reuse the allocation for the next stat
 		}
 	}
 }

--- a/net_sink.go
+++ b/net_sink.go
@@ -157,12 +157,12 @@ func (w *sinkWriter) Write(p []byte) (int, error) {
 }
 
 func (s *netSink) Flush() {
-	// forcefully flush the buffer to outc which will send immediately if batching is disabled
+	// forcefully flush the buffer to outc which will start sending immediately if batching is disabled
 	if s.flush() != nil {
 		return // nothing we can do
 	}
 	ch := make(chan struct{})
-	s.doFlush <- ch // send collected outc batches
+	s.doFlush <- ch // send collected outc batches and anything pre-batched in outc
 	<-ch
 }
 
@@ -280,12 +280,12 @@ func (s *netSink) run() {
 
 	batchSize := GetSettings().BatchSize
 	isBatchEnabled := batchSize > 0
-	batch := make([]bytes.Buffer, 0, batchSize) // todo do we need to worry about cap(s.outc)? it's a buffered channel but the read is one at a time anyway
+	batch := make([]bytes.Buffer, 0, batchSize) // todo do we need to worry about cap(s.outc)? it's a buffered channel but the write to batch, is one at a time anyway
 
 	t := time.NewTicker(flushInterval)
 	defer t.Stop()
 
-	// flush all buffered stats and send loop
+	// flush all/any buffered stats (on specified ticker) and send loop
 	for {
 		// writeToConn will set s.conn to nil on error, try to reconnect
 		if s.conn == nil {

--- a/net_sink.go
+++ b/net_sink.go
@@ -319,7 +319,7 @@ func (s *netSink) run() {
 				s.mu.Unlock()
 			}
 			putBuffer(buf)
-			continue // incase there's more to retry, continue loop to clear all retries first
+			continue // if error we may need to reconnect so go back to the top of the next itteration and maybe there's more to retry, continue loop to clear all retries first
 		default:
 			// Drop through in case retryc has nothing.
 		}
@@ -407,8 +407,8 @@ func (s *netSink) sendBatch(batch []bytes.Buffer) ([]bytes.Buffer, error) {
 
 	var err error
 	if i != n {
-		i++ // the current element is in and will be processed over the retry channel
-		err = fmt.Errorf("batch send failure, only sent %d of %d", i, n)
+		i++                                                              // the current element is in and will be processed over the retry channel
+		err = fmt.Errorf("batch send failure, only sent %d of %d", i, n) // todo log this
 	}
 
 	return batch[i:n:n], err // return items in batch which we haven't sent

--- a/net_sink.go
+++ b/net_sink.go
@@ -341,7 +341,7 @@ func (s *netSink) run() {
 
 		// for non-batching: always nil using genericSender
 		if err := sender.processBatch(); err != nil {
-			continue // if we're here assume an error occured and the batch hasn't finished sending, in this case s.conn is probably nil and we have a stat to retry. cut the iteration to the top
+			continue // if we're here assume an error occurred and the batch hasn't finished sending, in this case s.conn is probably nil and we have a stat to retry. cut the iteration to the top
 		}
 
 		select {

--- a/net_sink.go
+++ b/net_sink.go
@@ -119,7 +119,7 @@ func NewNetSink(opts ...SinkOption) FlushableSink {
 	}
 
 	s.outc = make(chan *bytes.Buffer, approxMaxMemBytes/bufSize) // todo: this creates a channel with a buffer of 2928 for udp and 64 for tcp do we need to influence batch size based on this?
-	s.retryc = make(chan *bytes.Buffer, 1)                       // It should be okay to limit this given we preferentially process from this over outc.
+	s.retryc = make(chan *bytes.Buffer, 1)                       // It should be okay to limit this given once we write to the retry channel we break the connection, and in subsequent processing we preferentially process from this over outc.
 
 	writer := &sinkWriter{outc: s.outc}
 	s.bufWriter = bufio.NewWriterSize(writer, bufSize)
@@ -280,7 +280,8 @@ func (s *netSink) run() {
 
 	batchSize := GetSettings().BatchSize
 	isBatchEnabled := batchSize > 0
-	batch := make([]bytes.Buffer, 0, batchSize) // todo do we need to worry about cap(s.outc)? it's a buffered channel but the write to batch, is one at a time anyway
+	batch := make([]bytes.Buffer, 0, batchSize)
+	sendBatch := false
 
 	t := time.NewTicker(flushInterval)
 	defer t.Stop()
@@ -306,7 +307,7 @@ func (s *netSink) run() {
 			reconnectFailed = false
 		}
 
-		// Handle buffers that need to be retried first, if they exist.
+		// Drain all retries first
 		select {
 		case buf := <-s.retryc:
 			if err := s.writeToConn(buf); err != nil {
@@ -315,14 +316,20 @@ func (s *netSink) run() {
 				s.mu.Unlock()
 			}
 			putBuffer(buf)
-			continue
+			continue // incase there's more to retry, continue loop to clear all retries first
 		default:
 			// Drop through in case retryc has nothing.
 		}
 
-		// send batched outc data anytime we're full and can't batch anymore
-		if len(batch) == cap(batch) {
-			batch = s.sendBatch(batch)
+		// send batched outc data anytime indicated or the batch is full
+		if sendBatch || len(batch) == cap(batch) {
+			var err error
+			batch, err = s.sendBatch(batch)
+			if err != nil {
+				sendBatch = true // guarentee we conitnue to complete sending the batch after retrying and before procecessing anything else
+				continue         // cut the iteration to process retries (nothing can be sent anyway since writeToConn failure with set s.conn to nil)
+			}
+			sendBatch = false
 		}
 
 		// flush buffer to outc and batch and/or send outc
@@ -330,8 +337,8 @@ func (s *netSink) run() {
 		case <-t.C:
 			s.flush() // from a higher level, stats are written to s.bufWriter.buf at GOSTATS_FLUSH_INTERVAL_SECONDS (or adhoc for Timers). this flushes them to outc every t.C tick
 		case done := <-s.doFlush:
-			// send batched outc data
-			batch = s.sendBatch(batch)
+			// indicate batched outc data to be sent in the next iteration
+			sendBatch = true
 
 			// drain and send remaining outc data
 			// todo re-evaluate: this code is probably redundant, outc should naturally become empty with `case buf := <-s.outc`, why is a forced drain required?
@@ -366,16 +373,26 @@ func (s *netSink) send(buf *bytes.Buffer) error {
 	return nil
 }
 
-func (s *netSink) sendBatch(batch []bytes.Buffer) []bytes.Buffer {
+func (s *netSink) sendBatch(batch []bytes.Buffer) ([]bytes.Buffer, error) {
 	n := len(batch)
-	for i := 0; i < n && s.conn != nil; i++ {
+
+	var i int
+	for i = 0; i < n && s.conn != nil; i++ {
 		buf := batch[i]
 		// todo can we just send all the batches in one call?
 		if err := s.send(&buf); err == nil {
 			putBuffer(&buf)
 		}
+		// if an error occurs we send the metric to the retry channel and make s.conn nil, breaking this loop and preventing further batch processing in this stack
 	}
-	return batch[:0]
+
+	var err error
+	if i != n {
+		i += 1 // the current element is in and will be processed over the retry channel
+		err = fmt.Errorf("batch send failure, only sent %d of %d", i, n)
+	}
+
+	return batch[i:n:n], err // return items in batch which we haven't sent
 }
 
 // writeToConn writes the buffer to the underlying conn.  May only be called

--- a/net_sink.go
+++ b/net_sink.go
@@ -118,7 +118,7 @@ func NewNetSink(opts ...SinkOption) FlushableSink {
 		bufSize = defaultBufferSizeTCP
 	}
 
-	s.outc = make(chan *bytes.Buffer, approxMaxMemBytes/bufSize) // todo: need to understand why/how this number was chosen and probably elevate it
+	s.outc = make(chan *bytes.Buffer, approxMaxMemBytes/bufSize) // todo: this computes to a buffer of 2928 for udp and 64 for tcp do we need to influence batch size based on this?
 	s.retryc = make(chan *bytes.Buffer, 1)                       // It should be okay to limit this given we preferentially process from this over outc.
 
 	writer := &sinkWriter{outc: s.outc}
@@ -157,11 +157,12 @@ func (w *sinkWriter) Write(p []byte) (int, error) {
 }
 
 func (s *netSink) Flush() {
+	// flushed buffer to outc which will write immediately
 	if s.flush() != nil {
 		return // nothing we can do
 	}
 	ch := make(chan struct{})
-	s.doFlush <- ch
+	s.doFlush <- ch // send batches
 	<-ch
 }
 
@@ -277,13 +278,14 @@ func (s *netSink) run() {
 
 	var reconnectFailed bool // true if last reconnect failed
 
-	batch := GetSettings().ForcedBatching
-	batches := make([]bytes.Buffer, 0, cap(s.outc)*4) // todo parameterize
+	batchSize := GetSettings().BatchSize
+	isBatchEnabled := batchSize > 0
+	batch := make([]bytes.Buffer, 0, batchSize) // todo do we need to worry about cap(s.outc)? it's a buffered channel but the read is one at a time anyway
 
 	t := time.NewTicker(flushInterval)
 	defer t.Stop()
 
-	// metric write loop (actively draining content of outc channel)
+	// stat flush and write loop
 	for {
 		if s.conn == nil {
 			if err := s.connect(addr); err != nil {
@@ -311,54 +313,57 @@ func (s *netSink) run() {
 				s.handleFlushErrorSize(err, buf.Len())
 				s.mu.Unlock()
 			}
-			putBuffer(buf) // todo understand: we write the stats buffer we have successfully sent to a pool, but anytime we access data from that pool, we clear it and reuse the allocation for the next stat
+			putBuffer(buf)
 			continue
 		default:
 			// Drop through in case retryc has nothing.
 		}
 
-		if len(batches) == cap(batches) {
-			s.doFlush <- make(chan struct{}) // todo in other writes to doFlush we block until the channel is closed, but since we're calling it from the same go routine we won't . it'll be better to factor to not rely on the channel for all writes
+		// send batch if full
+		if len(batch) == cap(batch) {
+			batch = s.sendBatch(batch)
 		}
 
+		// flush to outc and batch and/or send outc
 		select {
 		case done := <-s.doFlush:
-			n := len(batches)
-			for i := 0; i < n && s.conn != nil; i++ {
-				buf := batches[i]
-				if err := s.writeToConn(&buf); err != nil {
-					s.retryc <- &buf
-					continue
-				}
-				putBuffer(&buf) // todo understand: we write the stats buffer we have successfully sent to a pool, but anytime we access data from that pool, we clear it and reuse the allocation for the next stat
-			}
-			batches = batches[:0]
+			// send batch on doFlush signal
+			batch = s.sendBatch(batch)
 			close(done)
 		case buf := <-s.outc:
-			// Normally we will send stats anytime outc has data
-			//
-			// Gauages and Counters are written to outc at a cadence of GOSTATS_FLUSH_INTERVAL_SECONDS
-			// Timers are written adhoc to outc
-			//
-			// With batch we will rely on doFlush which is also controlled by the GOSTATS_FLUSH_INTERVAL_SECONDS
-			//
-			// Side effects:
-			// * Implied Timer batching under the flush interval
-			// * ~1 second delay to Gauge and Counter writes by batching these writes to the next internval
-			if batch {
-				batches = append(batches, *buf)
+			if isBatchEnabled {
+				// Batch outc data rely on doFlush signal to send
+				batch = append(batch, *buf)
 				continue
 			}
-			if err := s.writeToConn(buf); err != nil {
-				s.retryc <- buf
-				continue
+			// Without batching we will send stats if outc has data
+			if err := s.send(buf); err == nil {
+				putBuffer(buf)
 			}
-			putBuffer(buf) // todo understand: we write the stats buffer we have successfully sent to a pool, but anytime we access data from that pool, we clear it and reuse the allocation for the next stat
 		case <-t.C:
-			// todo understand: if the outc channel is full this will block? but it won't ever since it's the last select
 			s.flush() // from a higher level, stats write to s.bufWriter at GOSTATS_FLUSH_INTERVAL_SECONDS (or adhoc for Timers). this flushes them to outc every t.C tick
 		}
 	}
+}
+
+func (s *netSink) send(buf *bytes.Buffer) error {
+	if err := s.writeToConn(buf); err != nil {
+		s.retryc <- buf
+		return err
+	}
+	return nil
+}
+
+func (s *netSink) sendBatch(batch []bytes.Buffer) []bytes.Buffer {
+	n := len(batch)
+	for i := 0; i < n && s.conn != nil; i++ {
+		buf := batch[i]
+		// todo can we just send all the batches in one call?
+		if err := s.send(&buf); err == nil {
+			putBuffer(&buf)
+		}
+	}
+	return batch[:0]
 }
 
 // writeToConn writes the buffer to the underlying conn.  May only be called

--- a/net_sink.go
+++ b/net_sink.go
@@ -283,7 +283,7 @@ func (s *netSink) run() {
 
 	batchSize := settings.BatchSize
 	isBatchEnabled := batchSize > 0
-	batch := make([]bytes.Buffer, 0, batchSize+cap(s.outc)) // overallocate to consider draining all outc data. despite the exppanded allocation, batchSize is still used to determine if we send the batched stats
+	batch := make([]bytes.Buffer, 0, batchSize+cap(s.outc)) // overallocate to consider draining all outc data. despite the expanded allocation, batchSize is still used to determine if we send the batched stats
 	sendBatch := false
 	batchTimeout := time.Duration(settings.FlushIntervalS) * time.Second // todo: is there any need to use a new configuration for this?
 	batchInterval := time.After(batchTimeout)

--- a/net_sink.go
+++ b/net_sink.go
@@ -345,13 +345,16 @@ func (s *netSink) run() {
 		// flush buffer to outc
 		// from a higher level, stats are written to s.bufWriter.buf at GOSTATS_FLUSH_INTERVAL_SECONDS (or adhoc for Timers). this flushes them to outc every t.C tick
 		case <-t.C:
-			s.flush() // todo: if outc is at cap don't we risk blocking if we don't prioritizing reading it or would the flush error out?
+			s.flush() // if outc is or becomes full the sinkWriter will error and we will gracefully drop the remainding buffered stats
 
 			select {
 			case <-batchInterval:
 				if len(batch) > 0 {
 					sendBatch = true
+				} else {
+					batchInterval = time.After(batchTimeout)
 				}
+
 			default:
 			}
 		// drain all outc data. either batch or send immediatedly

--- a/net_sink.go
+++ b/net_sink.go
@@ -280,7 +280,7 @@ func (s *netSink) run() {
 
 	batchSize := GetSettings().BatchSize
 	isBatchEnabled := batchSize > 0
-	batch := make([]bytes.Buffer, 0, batchSize)
+	batch := make([]bytes.Buffer, 0, batchSize+cap(s.outc)) // expand allocation to allow for draining outc. todo change to an array to optimize
 	sendBatch := false
 
 	t := time.NewTicker(flushInterval)
@@ -322,7 +322,7 @@ func (s *netSink) run() {
 		}
 
 		// send batched outc data anytime indicated or the batch is full
-		if sendBatch || len(batch) == cap(batch) {
+		if sendBatch || len(batch) == batchSize {
 			var err error
 			batch, err = s.sendBatch(batch)
 			if err != nil {
@@ -334,11 +334,19 @@ func (s *netSink) run() {
 
 		// flush buffer to outc and batch and/or send outc
 		select {
-		case <-t.C:
+		case <-t.C: // todo: should this not be the last case? if outc is at cap don't we risk blocking if we don't prioritizing reading/draining it? or just do some precalculation and error in the flush for this case?
 			s.flush() // from a higher level, stats are written to s.bufWriter.buf at GOSTATS_FLUSH_INTERVAL_SECONDS (or adhoc for Timers). this flushes them to outc every t.C tick
 		case done := <-s.doFlush:
-			// indicate batched outc data to be sent in the next iteration
-			sendBatch = true
+			if isBatchEnabled {
+				n := len(s.outc)                          // Only flush pending buffers, this prevents an issue where continuous writes prevent the flush loop from exiting.
+				for i := 0; i < n && s.conn != nil; i++ { // todo: this can cause batch to exceed allocation if current cap(batch) is small, if cap(batch) - len(batch) is less than the len(s.outc) we are draining
+					buf := <-s.outc
+					batch = append(batch, *buf)
+				}
+				// indicate batched outc data to be sent in the next iteration
+				sendBatch = true
+				continue
+			}
 
 			// drain and send remaining outc data
 			// todo re-evaluate: this code is probably redundant, outc should naturally become empty with `case buf := <-s.outc`, why is a forced drain required?
@@ -357,11 +365,13 @@ func (s *netSink) run() {
 				batch = append(batch, *buf)
 				continue
 			}
+
 			// send outc data immediately
 			if err := s.send(buf); err == nil {
 				putBuffer(buf)
 			}
 		}
+
 	}
 }
 
@@ -379,7 +389,7 @@ func (s *netSink) sendBatch(batch []bytes.Buffer) ([]bytes.Buffer, error) {
 	var i int
 	for i = 0; i < n && s.conn != nil; i++ {
 		buf := batch[i]
-		// todo can we just send all the batches in one call?
+		// todo: can we just send all the batches in one call? for tcp we might just be able to seperate with \n for and let `_, err := buf.WriteTo(s.conn)` write all at once... they should already be seperated this way looking at netSink.Flush*
 		if err := s.send(&buf); err == nil {
 			putBuffer(&buf)
 		}

--- a/net_sink.go
+++ b/net_sink.go
@@ -284,9 +284,10 @@ func (s *netSink) run() {
 	isBatchEnabled := batchSize > 0
 	batch := make([]bytes.Buffer, 0, batchSize+cap(s.outc)) // expand allocation to allow for draining outc. todo change to an array to optimize
 	sendBatch := false
+	batchTimeout := time.Duration(settings.FlushIntervalS) * time.Second // todo maybe use a new configuration for batch flush interval
+	batchInterval := time.After(batchTimeout)
 
 	t := time.NewTicker(flushInterval)
-	bt := time.NewTicker(time.Duration(settings.FlushIntervalS) * time.Second) // todo maybe use a new configuration for batch flush interval
 	defer t.Stop()
 
 	// flush all/any buffered stats (on specified ticker) and send loop
@@ -329,16 +330,25 @@ func (s *netSink) run() {
 			var err error
 			batch, err = s.sendBatch(batch)
 			if err != nil {
-				sendBatch = true // guarentee for all cases that we complete sending the batch after retrying and before procecessing anything else
+				sendBatch = true // guarantee for all cases that we complete sending the batch after retrying and before procecessing anything else
 				continue         // cut the iteration to process retries (nothing can be sent anyway since writeToConn failure with set s.conn to nil)
 			}
 			sendBatch = false
+			batchInterval = time.After(batchTimeout)
 		}
 
 		// flush buffer to outc and batch and/or send outc
 		select {
 		case <-t.C: // todo: should this not be the last case? if outc is at cap don't we risk blocking if we don't prioritizing reading/draining it? or just do some precalculation and error in the flush for this case?
 			s.flush() // from a higher level, stats are written to s.bufWriter.buf at GOSTATS_FLUSH_INTERVAL_SECONDS (or adhoc for Timers). this flushes them to outc every t.C tick
+
+			select {
+			case <-batchInterval:
+				if len(batch) > 0 {
+					sendBatch = true
+				}
+			default:
+			}
 		case done := <-s.doFlush:
 			if isBatchEnabled {
 				n := len(s.outc)                          // Only flush pending buffers, this prevents an issue where continuous writes prevent the flush loop from exiting.
@@ -348,18 +358,17 @@ func (s *netSink) run() {
 				}
 				// indicate batched outc data to be sent in the next iteration
 				sendBatch = true
-				continue
-			}
-
-			// drain and send remaining outc data
-			// todo re-evaluate: this code is probably redundant, outc should naturally become empty with `case buf := <-s.outc`, why is a forced drain required?
-			n := len(s.outc) // Only flush pending buffers, this prevents an issue where continuous writes prevent the flush loop from exiting.
-			for i := 0; i < n && s.conn != nil; i++ {
-				buf := <-s.outc
-				if err := s.send(buf); err == nil {
-					putBuffer(buf)
+			} else {
+				// drain and send remaining outc data
+				// todo re-evaluate: this code is probably redundant, outc should naturally become empty with `case buf := <-s.outc`, why is a forced drain required?
+				n := len(s.outc) // Only flush pending buffers, this prevents an issue where continuous writes prevent the flush loop from exiting.
+				for i := 0; i < n && s.conn != nil; i++ {
+					buf := <-s.outc
+					if err := s.send(buf); err == nil {
+						putBuffer(buf)
+					}
+					// if an error occurs we send the metric to the retry channel and make s.conn nil, breaking this loop and preventing further batch processing in this stack
 				}
-				// if an error occurs we send the metric to the retry channel and make s.conn nil, breaking this loop and preventing further batch processing in this stack
 			}
 
 			close(done)
@@ -374,12 +383,6 @@ func (s *netSink) run() {
 			if err := s.send(buf); err == nil {
 				putBuffer(buf)
 			}
-		}
-
-		select {
-		case <-bt.C:
-			sendBatch = true
-		default:
 		}
 	}
 }
@@ -411,7 +414,7 @@ func (s *netSink) sendBatch(batch []bytes.Buffer) ([]bytes.Buffer, error) {
 		err = fmt.Errorf("batch send failure, only sent %d of %d", i, n) // todo log this
 	}
 
-	return batch[i:n:n], err // return items in batch which we haven't sent
+	return batch[i:n:n], err // return items in batch which we haven't sent. todo make sure the data in retryc is not duplicated in our response batch, otherwise we may infinite loop
 }
 
 // writeToConn writes the buffer to the underlying conn.  May only be called

--- a/net_sink.go
+++ b/net_sink.go
@@ -315,6 +315,7 @@ func (s *netSink) run() {
 			// Drop through in case retryc has nothing.
 		}
 
+		// if the channel is at capacity, it's blocking, let's signal for it to be flushed and unblock
 		if len(s.outc) == cap(s.outc) {
 			s.Flush()
 		}
@@ -340,9 +341,16 @@ func (s *netSink) run() {
 		case <-t.C:
 			s.flush()
 		case buf := <-s.outc:
-			// naturally we will write anytime ve data here. since timers are actively/adhoc written to outc there is no batching or flush control (gauages and counters only write data to outc at a cadence of GOSTATS_FLUSH_INTERVAL_SECONDS)
-			// by skipping this we move ourselves to just relying on doFlush which is also controlled by the GOSTATS_FLUSH_INTERVAL_SECONDS ticker
-			// maybe delaying gauges and counters writes by a second, but importantly implying timer writes at an interval, not just whenever
+			// Normally we will write anytime outc has data
+			//
+			// Gauages and Counters are written to outc at a cadence of GOSTATS_FLUSH_INTERVAL_SECONDS
+			// Timers are written adhoc to outc
+			//
+			// With delayedFlush we will rely on doFlush which is also controlled by the GOSTATS_FLUSH_INTERVAL_SECONDS
+			//
+			// Side effects:
+			// * Delayed Gauge and Counter writes by batching these at the end of the interval
+			// * Implied Timer batching and writing under the flush interval
 			if delayedFlush {
 				continue
 			}

--- a/net_sink.go
+++ b/net_sink.go
@@ -276,6 +276,8 @@ func (s *netSink) run() {
 	addr := net.JoinHostPort(s.conf.StatsdHost, strconv.Itoa(s.conf.StatsdPort))
 	batch := GetSettings().ForcedBatching
 
+	batchc := make(chan *bytes.Buffer, cap(s.outc))
+
 	var reconnectFailed bool // true if last reconnect failed
 
 	t := time.NewTicker(flushInterval)
@@ -322,26 +324,21 @@ func (s *netSink) run() {
 
 		select {
 		case done := <-s.doFlush:
-			// Only flush pending buffers, this prevents an issue where
-			// continuous writes prevent the flush loop from exiting.
-			//
-			// If there is an error writeToConn() will set the conn to
-			// nil thus breaking the loop.
-			//
-			n := len(s.outc)
+			n := len(batchc)
 			for i := 0; i < n && s.conn != nil; i++ {
-				buf := <-s.outc
+				buf := <-batchc
 				if err := s.writeToConn(buf); err != nil {
 					s.retryc <- buf
 					continue
 				}
 				putBuffer(buf)
 			}
+
 			close(done)
 		case <-t.C:
 			s.flush()
 		case buf := <-s.outc:
-			// Normally we will write anytime outc has data
+			// Normally we will send stats anytime outc has data
 			//
 			// Gauages and Counters are written to outc at a cadence of GOSTATS_FLUSH_INTERVAL_SECONDS
 			// Timers are written adhoc to outc
@@ -349,9 +346,10 @@ func (s *netSink) run() {
 			// With batch we will rely on doFlush which is also controlled by the GOSTATS_FLUSH_INTERVAL_SECONDS
 			//
 			// Side effects:
-			// * Delayed Gauge and Counter writes by batching these at the end of the interval
-			// * Implied Timer batching and writing under the flush interval
+			// * Implied Timer batching under the flush interval
+			// * < 1 second delay to Gauge and Counter writes by batching these at the end of the interval
 			if batch {
+				batchc <- buf
 				continue
 			}
 			if err := s.writeToConn(buf); err != nil {

--- a/net_sink.go
+++ b/net_sink.go
@@ -286,7 +286,7 @@ func (s *netSink) run() {
 	batchTimeout := time.Duration(s.conf.BatchSendIntervalS) * time.Second
 	batchInterval := time.After(batchTimeout)
 
-	sendBatch := false
+	doSendBatch := false
 
 	t := time.NewTicker(flushInterval)
 	defer t.Stop()
@@ -330,14 +330,14 @@ func (s *netSink) run() {
 		}
 
 		// send batched outc data anytime indicated or the batch is full
-		if sendBatch || len(batch) >= batchSize {
+		if doSendBatch || len(batch) >= batchSize {
 			var err error
 			batch, err = s.sendBatch(batch)
 			if err != nil {
-				sendBatch = true // indicate to continue sending out the batch in the next iterration if any erros occur (needed if entering from len(batch) >= batchSize)
-				continue         // cut the iteration to process retry (s.conn will be nil anyway)
+				doSendBatch = true // indicate to continue sending out the batch in the next iterration if any erros occur (needed if entering from len(batch) >= batchSize)
+				continue           // cut the iteration to process retry (s.conn will be nil anyway)
 			}
-			sendBatch = false
+			doSendBatch = false
 			batchInterval = time.After(batchTimeout)
 		}
 
@@ -350,7 +350,7 @@ func (s *netSink) run() {
 			select {
 			case <-batchInterval:
 				if len(batch) > 0 {
-					sendBatch = true
+					doSendBatch = true
 				} else {
 					batchInterval = time.After(batchTimeout)
 				}
@@ -365,7 +365,7 @@ func (s *netSink) run() {
 					buf := <-s.outc
 					batch = append(batch, *buf)
 				}
-				sendBatch = true // indicate batched outc data to be sent in the next iteration
+				doSendBatch = true // indicate batched outc data to be sent in the next iteration
 			} else {
 				n := len(s.outc) // Only flush pending buffers, this prevents an issue where continuous writes prevent the flush loop from exiting.
 				for i := 0; i < n && s.conn != nil; i++ {

--- a/net_sink.go
+++ b/net_sink.go
@@ -297,7 +297,7 @@ func (s *netSink) run() {
 		// writeToConn will set s.conn to nil on error, try to reconnect
 		if s.conn == nil {
 			// connect to statsd server
-			// the connection will be persisted unless an error occurs. thereby with batching is used the entire batch will be streamed under 1 connection
+			// the connection will be persisted unless an error occurs. thereby when batching is used the entire batch will be streamed under 1 connection
 			if err := s.connect(addr); err != nil {
 				s.log.Warnf("connection error: %s", err)
 
@@ -324,7 +324,7 @@ func (s *netSink) run() {
 				s.mu.Unlock()
 			}
 			putBuffer(buf)
-			continue // if error we may need to reconnect so go back to the top of the next iteration
+			continue // we will need to reconnect if an error occurs, so go back to the top of the next iteration to see
 		default:
 			// Drop through in case retryc has nothing.
 		}
@@ -354,8 +354,8 @@ func (s *netSink) run() {
 				} else {
 					batchInterval = time.After(batchTimeout)
 				}
-
 			default:
+				// No need to block here, drop through check again in the next t.C interval
 			}
 		// drain all outc data. either batch or send immediatedly
 		case done := <-s.doFlush:

--- a/net_sink.go
+++ b/net_sink.go
@@ -283,7 +283,7 @@ func (s *netSink) run() {
 
 	batchSize := settings.BatchSize
 	isBatchEnabled := batchSize > 0
-	batch := make([]bytes.Buffer, 0, batchSize+cap(s.outc)) // expand allocation to allow for draining outc. todo change to an array to optimize
+	batch := make([]bytes.Buffer, 0, batchSize+cap(s.outc)) // overallocate to consider draining all outc data. despite the exppanded allocation, batchSize is still used to determine if we send the batched stats
 	sendBatch := false
 	batchTimeout := time.Duration(settings.FlushIntervalS) * time.Second // todo: is there any need to use a new configuration for this?
 	batchInterval := time.After(batchTimeout)
@@ -360,7 +360,7 @@ func (s *netSink) run() {
 				n := len(s.outc)
 				for i := 0; i < n && s.conn != nil; i++ {
 					buf := <-s.outc
-					batch = append(batch, *buf) // todo: we may exceed allocation here if if current cap(batch) is small, if cap(batch) - len(batch) is less than the len(s.outc) we are draining
+					batch = append(batch, *buf)
 				}
 				sendBatch = true // indicate batched outc data to be sent in the next iteration
 			} else {
@@ -411,11 +411,10 @@ func (s *netSink) sendBatch(batch []bytes.Buffer) ([]bytes.Buffer, error) {
 
 	var err error
 	if i != n {
-		i++                                                              // the current element will be processed over the retry channel so assume it processed from the batch
-		err = fmt.Errorf("batch send failure, only sent %d of %d", i, n) // todo log this
+		err = fmt.Errorf("batch send failure, only sent %d of %d", i, n)
 	}
 
-	return batch[i:n:n], err // return items in batch which we haven't sent. todo: make sure the data in retryc is not duplicated in our response batch, otherwise we may infinite loop
+	return batch[i:n:n], err
 }
 
 // writeToConn writes the buffer to the underlying conn.  May only be called

--- a/net_sink_test.go
+++ b/net_sink_test.go
@@ -943,6 +943,60 @@ func TestFlushTimerBatchingForUDP(t *testing.T) {
 	os.Unsetenv("GOSTATS_BATCH_SIZE")
 }
 
+func TestFlushTimerBatchingAutoSendEveryBatch(t *testing.T) {
+	err1 := os.Setenv("GOSTATS_BATCH_SIZE", "1")
+	err2 := os.Setenv("GOSTATS_FLUSH_INTERVAL_SECONDS", "5")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("Failed to set environment variable. GOSTATS_BATCH_SIZE: %s, GOSTATS_FLUSH_INTERVAL_SECONDS: %s", err1, err2)
+	}
+
+	expected := 3840
+
+	ts, sink := setupTestNetSink(t, "tcp", false)
+	defer ts.Close()
+
+	for i := 0; i < 256; i++ {
+		sink.FlushTimer("timer_int", float64(i%10))
+	}
+
+	time.Sleep(2001 * time.Millisecond)
+
+	bufferSizer := len(ts.String())
+	if bufferSizer != expected {
+		t.Errorf("Not all stats were written\ngot buffer size:\n%d\nwanted:\n%d\n", bufferSizer, expected)
+	}
+
+	os.Unsetenv("GOSTATS_BATCH_SIZE")
+	os.Unsetenv("GOSTATS_FLUSH_INTERVAL_SECONDS")
+}
+
+func TestFlushTimerBatchingAutoSendAfterTimerout(t *testing.T) {
+	err1 := os.Setenv("GOSTATS_BATCH_SIZE", "300")
+	err2 := os.Setenv("GOSTATS_FLUSH_INTERVAL_SECONDS", "5")
+	if err1 != nil || err2 != nil {
+		t.Fatalf("Failed to set environment variable. GOSTATS_BATCH_SIZE: %s, GOSTATS_FLUSH_INTERVAL_SECONDS: %s", err1, err2)
+	}
+
+	expected := 3840
+
+	ts, sink := setupTestNetSink(t, "tcp", false)
+	defer ts.Close()
+
+	for i := 0; i < 256; i++ {
+		sink.FlushTimer("timer_int", float64(i%10))
+	}
+
+	time.Sleep(6001 * time.Millisecond)
+
+	bufferSizer := len(ts.String())
+	if bufferSizer != expected {
+		t.Errorf("Not all stats were written\ngot buffer size:\n%d\nwanted:\n%d\n", bufferSizer, expected)
+	}
+
+	os.Unsetenv("GOSTATS_BATCH_SIZE")
+	os.Unsetenv("GOSTATS_FLUSH_INTERVAL_SECONDS")
+}
+
 func TestNetSink_Integration_TCP(t *testing.T) {
 	testNetSinkIntegration(t, "tcp")
 }

--- a/net_sink_test.go
+++ b/net_sink_test.go
@@ -847,6 +847,68 @@ func testNetSinkIntegration(t *testing.T, protocol string) {
 	})
 }
 
+func TestFlushTimerNoBatching(t *testing.T) {
+	err := os.Setenv("GOSTATS_FORCED_BATCHING", "false")
+	if err != nil {
+		t.Fatalf("Failed to set environment variable: %s", err)
+	}
+
+	expected := [...]string{
+		"timer_int:1|ms\n",
+		"timer_float:1.230000|ms\n",
+	}
+
+	ts, sink := setupTestNetSink(t, "tcp", false) // the protocol is arbitrary and unimportant for batching
+	defer ts.Close()
+
+	sink.FlushTimer("timer_int", 1)
+	sink.FlushTimer("timer_float", 1.23)
+
+	time.Sleep(time.Second * 5)
+
+	exp := strings.Join(expected[:], "")
+	buf := ts.String()
+	if buf != exp {
+		t.Errorf("Not all stats were written\ngot:\n%q\nwant:\n%q\n", buf, exp)
+	}
+
+	os.Unsetenv("GOSTATS_FORCED_BATCHING")
+}
+
+func TestFlushTimerBatching(t *testing.T) {
+	err := os.Setenv("GOSTATS_FORCED_BATCHING", "true")
+	if err != nil {
+		t.Fatalf("Failed to set environment variable: %s", err)
+	}
+
+	expected := [...]string{
+		"timer_int:1|ms\n",
+		"timer_float:1.230000|ms\n",
+	}
+
+	ts, sink := setupTestNetSink(t, "tcp", false) // the protocol is arbitrary and unimportant for batching
+	defer ts.Close()
+
+	sink.FlushTimer("timer_int", 1)
+	sink.FlushTimer("timer_float", 1.23)
+	time.Sleep(time.Second * 5)
+
+	if ts.String() != "" {
+		t.Errorf("Stats were written despite forced batching")
+	}
+
+	sink.Flush()
+	time.Sleep(time.Second * 5)
+
+	exp := strings.Join(expected[:], "")
+	buf := ts.String()
+	if buf != exp {
+		t.Errorf("Not all stats were written\ngot:\n%q\nwant:\n%q\n", buf, exp)
+	}
+
+	os.Unsetenv("GOSTATS_FORCED_BATCHING")
+}
+
 func TestNetSink_Integration_TCP(t *testing.T) {
 	testNetSinkIntegration(t, "tcp")
 }

--- a/net_sink_test.go
+++ b/net_sink_test.go
@@ -848,7 +848,7 @@ func testNetSinkIntegration(t *testing.T, protocol string) {
 	})
 }
 
-func TestFlushTimerNoBatching(t *testing.T) {
+func TestNoBatching(t *testing.T) {
 	err := os.Setenv("GOSTATS_BATCH_SIZE", "0")
 	if err != nil {
 		t.Fatalf("Failed to set environment variable: %s", err)
@@ -876,77 +876,79 @@ func TestFlushTimerNoBatching(t *testing.T) {
 	os.Unsetenv("GOSTATS_BATCH_SIZE")
 }
 
-func TestFlushTimerBatchingForTCP(t *testing.T) {
-	err := os.Setenv("GOSTATS_BATCH_SIZE", "64")
-	if err != nil {
-		t.Fatalf("Failed to set environment variable: %s", err)
+func TestBatchingForTCP(t *testing.T) {
+	err1 := os.Setenv("GOSTATS_BATCH_SIZE", "300")
+	err2 := os.Setenv("GOSTATS_FLUSH_INTERVAL_SECONDS", "100000") // effectively disable batch send interval
+	if err1 != nil || err2 != nil {
+		t.Fatalf("Failed to set environment variable. GOSTATS_BATCH_SIZE: %s, GOSTATS_FLUSH_INTERVAL_SECONDS: %s", err1, err2)
 	}
 
-	expected := [...]string{
-		"timer_int:1|ms\n",
-		"timer_float:1.230000|ms\n",
-	}
+	expected := 3840
 
 	ts, sink := setupTestNetSink(t, "tcp", false)
 	defer ts.Close()
 
-	sink.FlushTimer("timer_int", 1)
-	sink.FlushTimer("timer_float", 1.23)
-	time.Sleep(2001 * time.Millisecond)
+	// more than outc capacity which is 64 for tcp, despite this our batch size is bigger and we should batch the data and only sendBatch once
+	for i := 0; i < 256; i++ {
+		sink.FlushTimer("timer_int", float64(i%10))
+	}
 
+	time.Sleep(2001 * time.Millisecond)
 	if ts.String() != "" {
 		t.Errorf("Stats were written despite forced batching")
 	}
 
-	sink.Flush()
-	time.Sleep(2001 * time.Millisecond)
+	sink.Flush() // drain all outc and send
 
-	exp := strings.Join(expected[:], "")
-	buf := ts.String()
-	if buf != exp {
-		t.Errorf("Not all stats were written\ngot:\n%q\nwant:\n%q\n", buf, exp)
+	time.Sleep(1000 * time.Millisecond)
+
+	bufferSize := len(ts.String())
+	if bufferSize != expected {
+		t.Errorf("Not all stats were written\ngot buffer size:\n%d\nwanted:\n%d\n", bufferSize, expected)
 	}
 
 	os.Unsetenv("GOSTATS_BATCH_SIZE")
+	os.Unsetenv("GOSTATS_FLUSH_INTERVAL_SECONDS")
 }
 
-func TestFlushTimerBatchingForUDP(t *testing.T) {
-	err := os.Setenv("GOSTATS_BATCH_SIZE", "2928")
-	if err != nil {
-		t.Fatalf("Failed to set environment variable: %s", err)
+func TestBatchingForUDP(t *testing.T) {
+	err1 := os.Setenv("GOSTATS_BATCH_SIZE", "5000")
+	err2 := os.Setenv("GOSTATS_FLUSH_INTERVAL_SECONDS", "100000") // effectively disable batch send interval
+	if err1 != nil || err2 != nil {
+		t.Fatalf("Failed to set environment variable. GOSTATS_BATCH_SIZE: %s, GOSTATS_FLUSH_INTERVAL_SECONDS: %s", err1, err2)
 	}
 
-	expected := [...]string{
-		"timer_int:1|ms\n",
-		"timer_float:1.230000|ms\n",
-	}
+	expected := 45000
 
 	ts, sink := setupTestNetSink(t, "udp", false)
 	defer ts.Close()
 
-	sink.FlushTimer("timer_int", 1)
-	sink.FlushTimer("timer_float", 1.23)
-	time.Sleep(2001 * time.Millisecond)
+	// more than outc capacity which is 2928 for udp, despite this our batch size is bigger and we should batch the data and only sendBatch once
+	for i := 0; i < 3000; i++ {
+		sink.FlushTimer("timer_int", float64(i%10))
+	}
 
+	time.Sleep(2001 * time.Millisecond)
 	if ts.String() != "" {
 		t.Errorf("Stats were written despite forced batching")
 	}
 
-	sink.Flush()
-	time.Sleep(2001 * time.Millisecond)
+	sink.Flush() // drain all outc and send
 
-	exp := strings.Join(expected[:], "")
-	buf := ts.String()
-	if buf != exp {
-		t.Errorf("Not all stats were written\ngot:\n%q\nwant:\n%q\n", buf, exp)
+	time.Sleep(1000 * time.Millisecond)
+
+	bufferSize := len(ts.String())
+	if bufferSize != expected {
+		t.Errorf("Not all stats were written\ngot buffer size:\n%d\nwanted:\n%d\n", bufferSize, expected)
 	}
 
 	os.Unsetenv("GOSTATS_BATCH_SIZE")
+	os.Unsetenv("GOSTATS_FLUSH_INTERVAL_SECONDS")
 }
 
-func TestFlushTimerBatchingAutoSendEveryBatch(t *testing.T) {
+func TestBatchingAutoSendWhenBatchIsFull(t *testing.T) {
 	err1 := os.Setenv("GOSTATS_BATCH_SIZE", "1")
-	err2 := os.Setenv("GOSTATS_FLUSH_INTERVAL_SECONDS", "5")
+	err2 := os.Setenv("GOSTATS_FLUSH_INTERVAL_SECONDS", "100000") // effectively disable batch send interval
 	if err1 != nil || err2 != nil {
 		t.Fatalf("Failed to set environment variable. GOSTATS_BATCH_SIZE: %s, GOSTATS_FLUSH_INTERVAL_SECONDS: %s", err1, err2)
 	}
@@ -960,20 +962,20 @@ func TestFlushTimerBatchingAutoSendEveryBatch(t *testing.T) {
 		sink.FlushTimer("timer_int", float64(i%10))
 	}
 
-	time.Sleep(2001 * time.Millisecond)
+	time.Sleep(2001 * time.Millisecond) // we only flush to outc ~every second but the batch will be sent ~immediately as it's always full
 
-	bufferSizer := len(ts.String())
-	if bufferSizer != expected {
-		t.Errorf("Not all stats were written\ngot buffer size:\n%d\nwanted:\n%d\n", bufferSizer, expected)
+	bufferSize := len(ts.String())
+	if bufferSize != expected {
+		t.Errorf("Not all stats were written\ngot buffer size:\n%d\nwanted:\n%d\n", bufferSize, expected)
 	}
 
 	os.Unsetenv("GOSTATS_BATCH_SIZE")
 	os.Unsetenv("GOSTATS_FLUSH_INTERVAL_SECONDS")
 }
 
-func TestFlushTimerBatchingAutoSendAfterTimerout(t *testing.T) {
-	err1 := os.Setenv("GOSTATS_BATCH_SIZE", "300")
-	err2 := os.Setenv("GOSTATS_FLUSH_INTERVAL_SECONDS", "5")
+func TestBatchingAutoSendOnInterval(t *testing.T) {
+	err1 := os.Setenv("GOSTATS_BATCH_SIZE", "10000")
+	err2 := os.Setenv("GOSTATS_FLUSH_INTERVAL_SECONDS", "2")
 	if err1 != nil || err2 != nil {
 		t.Fatalf("Failed to set environment variable. GOSTATS_BATCH_SIZE: %s, GOSTATS_FLUSH_INTERVAL_SECONDS: %s", err1, err2)
 	}
@@ -987,18 +989,18 @@ func TestFlushTimerBatchingAutoSendAfterTimerout(t *testing.T) {
 		sink.FlushTimer("timer_int", float64(i%10))
 	}
 
-	time.Sleep(6001 * time.Millisecond)
+	time.Sleep(3001 * time.Millisecond) // we only flush to outc ~every second and send the batch ~every 2 seconds
 
-	bufferSizer := len(ts.String())
-	if bufferSizer != expected {
-		t.Errorf("Not all stats were written\ngot buffer size:\n%d\nwanted:\n%d\n", bufferSizer, expected)
+	bufferSize := len(ts.String())
+	if bufferSize != expected {
+		t.Errorf("Not all stats were written\ngot buffer size:\n%d\nwanted:\n%d\n", bufferSize, expected)
 	}
 
 	os.Unsetenv("GOSTATS_BATCH_SIZE")
 	os.Unsetenv("GOSTATS_FLUSH_INTERVAL_SECONDS")
 }
 
-func TestNetSink_SendBatch_Error(t *testing.T) {
+func TestSendBatch_Error(t *testing.T) {
 	netSink, mockedConn := newErrorSink(1)
 
 	batch := []bytes.Buffer{

--- a/net_sink_test.go
+++ b/net_sink_test.go
@@ -2,6 +2,7 @@ package stats
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -995,6 +996,47 @@ func TestFlushTimerBatchingAutoSendAfterTimerout(t *testing.T) {
 
 	os.Unsetenv("GOSTATS_BATCH_SIZE")
 	os.Unsetenv("GOSTATS_FLUSH_INTERVAL_SECONDS")
+}
+
+func TestNetSink_SendBatch_Error(t *testing.T) {
+	netSink, mockedConn := newErrorSink(1)
+
+	batch := []bytes.Buffer{
+		*bytes.NewBufferString("metric1"),
+		*bytes.NewBufferString("metric2"),
+		*bytes.NewBufferString("metric3"),
+	}
+
+	remaining, err := netSink.sendBatch(batch)
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+
+	if len(remaining) != 1 {
+		t.Fatalf("expected 1 remaining buffer, got %d", len(remaining))
+	}
+
+	if remaining[0].String() != "metric3" {
+		t.Errorf("expected remaining buffer to be 'metric3', got '%s'", remaining[0].String())
+	}
+
+	select {
+	case retryStat := <-netSink.retryc:
+		if retryStat.String() != "metric2" {
+			t.Errorf("expected retry to be 'metric2', got %s", retryStat.String())
+		}
+	default:
+		t.Errorf("expected 1 retry, got none")
+	}
+
+	if len(mockedConn.writes) != 1 {
+		t.Fatalf("expected 1 write, got %d", len(mockedConn.writes))
+	}
+
+	writtenStat := string(mockedConn.writes[0])
+	if writtenStat != "metric1" {
+		t.Errorf("expected write to be 'metric1', got %s", writtenStat)
+	}
 }
 
 func TestNetSink_Integration_TCP(t *testing.T) {

--- a/net_sink_test.go
+++ b/net_sink_test.go
@@ -557,6 +557,7 @@ func setupTestNetSink(t *testing.T, protocol string, stop bool) (*netTestSink, *
 		}
 	}
 
+	// this naming is a bit misleading, it is just a wrapper for NewNetSink and nothing explicit to tcp is configured
 	sink := NewTCPStatsdSink(
 		WithLogger(discardLogger()),
 		WithStatsdHost(ts.Host(t)),
@@ -849,9 +850,9 @@ func testNetSinkIntegration(t *testing.T, protocol string) {
 }
 
 func TestNoBatching(t *testing.T) {
-	err := os.Setenv("GOSTATS_BATCH_SIZE", "0")
+	err := os.Setenv("GOSTATS_BATCH_ENABLED", "false")
 	if err != nil {
-		t.Fatalf("Failed to set environment variable: %s", err)
+		t.Fatalf("Failed to set GOSTATS_BATCH_ENABLED environment variable: %s", err)
 	}
 
 	expected := [...]string{
@@ -873,14 +874,21 @@ func TestNoBatching(t *testing.T) {
 		t.Errorf("Not all stats were written\ngot:\n%q\nwant:\n%q\n", buf, exp)
 	}
 
-	os.Unsetenv("GOSTATS_BATCH_SIZE")
+	os.Unsetenv("GOSTATS_BATCH_ENABLED")
 }
 
 func TestBatchingForTCP(t *testing.T) {
-	err1 := os.Setenv("GOSTATS_BATCH_SIZE", "300")
-	err2 := os.Setenv("GOSTATS_FLUSH_INTERVAL_SECONDS", "100000") // effectively disable batch send interval
-	if err1 != nil || err2 != nil {
-		t.Fatalf("Failed to set environment variable. GOSTATS_BATCH_SIZE: %s, GOSTATS_FLUSH_INTERVAL_SECONDS: %s", err1, err2)
+	err := os.Setenv("GOSTATS_BATCH_ENABLED", "true")
+	if err != nil {
+		t.Fatalf("Failed to set GOSTATS_BATCH_ENABLED environment variable: %s", err)
+	}
+	err = os.Setenv("GOSTATS_BATCH_SIZE", "300")
+	if err != nil {
+		t.Fatalf("Failed to set GOSTATS_BATCH_SIZE environment variable: %s", err)
+	}
+	err = os.Setenv("GOSTATS_BATCH_SEND_INTERVAL_SECONDS", "100000") // effectively disable batch send interval
+	if err != nil {
+		t.Fatalf("Failed to set GOSTATS_BATCH_SEND_INTERVAL_SECONDS environment variable: %s", err)
 	}
 
 	expected := 3840
@@ -907,15 +915,23 @@ func TestBatchingForTCP(t *testing.T) {
 		t.Errorf("Not all stats were written\ngot buffer size:\n%d\nwanted:\n%d\n", bufferSize, expected)
 	}
 
+	os.Unsetenv("GOSTATS_BATCH_ENABLED")
 	os.Unsetenv("GOSTATS_BATCH_SIZE")
-	os.Unsetenv("GOSTATS_FLUSH_INTERVAL_SECONDS")
+	os.Unsetenv("GOSTATS_BATCH_SEND_INTERVAL_SECONDS")
 }
 
 func TestBatchingForUDP(t *testing.T) {
-	err1 := os.Setenv("GOSTATS_BATCH_SIZE", "5000")
-	err2 := os.Setenv("GOSTATS_FLUSH_INTERVAL_SECONDS", "100000") // effectively disable batch send interval
-	if err1 != nil || err2 != nil {
-		t.Fatalf("Failed to set environment variable. GOSTATS_BATCH_SIZE: %s, GOSTATS_FLUSH_INTERVAL_SECONDS: %s", err1, err2)
+	err := os.Setenv("GOSTATS_BATCH_ENABLED", "true")
+	if err != nil {
+		t.Fatalf("Failed to set GOSTATS_BATCH_ENABLED environment variable: %s", err)
+	}
+	err = os.Setenv("GOSTATS_BATCH_SIZE", "5000")
+	if err != nil {
+		t.Fatalf("Failed to set GOSTATS_BATCH_SIZE environment variable: %s", err)
+	}
+	err = os.Setenv("GOSTATS_BATCH_SEND_INTERVAL_SECONDS", "100000") // effectively disable batch send interval
+	if err != nil {
+		t.Fatalf("Failed to set GOSTATS_BATCH_SEND_INTERVAL_SECONDS environment variable: %s", err)
 	}
 
 	expected := 45000
@@ -942,15 +958,23 @@ func TestBatchingForUDP(t *testing.T) {
 		t.Errorf("Not all stats were written\ngot buffer size:\n%d\nwanted:\n%d\n", bufferSize, expected)
 	}
 
+	os.Unsetenv("GOSTATS_BATCH_ENABLED")
 	os.Unsetenv("GOSTATS_BATCH_SIZE")
-	os.Unsetenv("GOSTATS_FLUSH_INTERVAL_SECONDS")
+	os.Unsetenv("GOSTATS_BATCH_SEND_INTERVAL_SECONDS")
 }
 
 func TestBatchingAutoSendWhenBatchIsFull(t *testing.T) {
-	err1 := os.Setenv("GOSTATS_BATCH_SIZE", "1")
-	err2 := os.Setenv("GOSTATS_FLUSH_INTERVAL_SECONDS", "100000") // effectively disable batch send interval
-	if err1 != nil || err2 != nil {
-		t.Fatalf("Failed to set environment variable. GOSTATS_BATCH_SIZE: %s, GOSTATS_FLUSH_INTERVAL_SECONDS: %s", err1, err2)
+	err := os.Setenv("GOSTATS_BATCH_ENABLED", "true")
+	if err != nil {
+		t.Fatalf("Failed to set GOSTATS_BATCH_ENABLED environment variable: %s", err)
+	}
+	err = os.Setenv("GOSTATS_BATCH_SIZE", "1")
+	if err != nil {
+		t.Fatalf("Failed to set GOSTATS_BATCH_SIZE environment variable: %s", err)
+	}
+	err = os.Setenv("GOSTATS_BATCH_SEND_INTERVAL_SECONDS", "100000") // effectively disable batch send interval
+	if err != nil {
+		t.Fatalf("Failed to set GOSTATS_BATCH_SEND_INTERVAL_SECONDS environment variable: %s", err)
 	}
 
 	expected := 3840
@@ -969,15 +993,23 @@ func TestBatchingAutoSendWhenBatchIsFull(t *testing.T) {
 		t.Errorf("Not all stats were written\ngot buffer size:\n%d\nwanted:\n%d\n", bufferSize, expected)
 	}
 
+	os.Unsetenv("GOSTATS_BATCH_ENABLED")
 	os.Unsetenv("GOSTATS_BATCH_SIZE")
-	os.Unsetenv("GOSTATS_FLUSH_INTERVAL_SECONDS")
+	os.Unsetenv("GOSTATS_BATCH_SEND_INTERVAL_SECONDS")
 }
 
 func TestBatchingAutoSendOnInterval(t *testing.T) {
-	err1 := os.Setenv("GOSTATS_BATCH_SIZE", "10000")
-	err2 := os.Setenv("GOSTATS_FLUSH_INTERVAL_SECONDS", "2")
-	if err1 != nil || err2 != nil {
-		t.Fatalf("Failed to set environment variable. GOSTATS_BATCH_SIZE: %s, GOSTATS_FLUSH_INTERVAL_SECONDS: %s", err1, err2)
+	err := os.Setenv("GOSTATS_BATCH_ENABLED", "true")
+	if err != nil {
+		t.Fatalf("Failed to set GOSTATS_BATCH_ENABLED environment variable: %s", err)
+	}
+	err = os.Setenv("GOSTATS_BATCH_SIZE", "10000")
+	if err != nil {
+		t.Fatalf("Failed to set GOSTATS_BATCH_SIZE environment variable: %s", err)
+	}
+	err = os.Setenv("GOSTATS_BATCH_SEND_INTERVAL_SECONDS", "2") // effectively disable batch send interval
+	if err != nil {
+		t.Fatalf("Failed to set GOSTATS_BATCH_SEND_INTERVAL_SECONDS environment variable: %s", err)
 	}
 
 	expected := 3840
@@ -996,8 +1028,9 @@ func TestBatchingAutoSendOnInterval(t *testing.T) {
 		t.Errorf("Not all stats were written\ngot buffer size:\n%d\nwanted:\n%d\n", bufferSize, expected)
 	}
 
+	os.Unsetenv("GOSTATS_BATCH_ENABLED")
 	os.Unsetenv("GOSTATS_BATCH_SIZE")
-	os.Unsetenv("GOSTATS_FLUSH_INTERVAL_SECONDS")
+	os.Unsetenv("GOSTATS_BATCH_SEND_INTERVAL_SECONDS")
 }
 
 func TestSendBatch_Error(t *testing.T) {

--- a/net_sink_test.go
+++ b/net_sink_test.go
@@ -864,7 +864,7 @@ func TestFlushTimerNoBatching(t *testing.T) {
 	sink.FlushTimer("timer_int", 1)
 	sink.FlushTimer("timer_float", 1.23)
 
-	time.Sleep(time.Second * 5)
+	time.Sleep(2001 * time.Millisecond)
 
 	exp := strings.Join(expected[:], "")
 	buf := ts.String()
@@ -891,14 +891,14 @@ func TestFlushTimerBatching(t *testing.T) {
 
 	sink.FlushTimer("timer_int", 1)
 	sink.FlushTimer("timer_float", 1.23)
-	time.Sleep(time.Second * 5)
+	time.Sleep(2001 * time.Millisecond)
 
 	if ts.String() != "" {
 		t.Errorf("Stats were written despite forced batching")
 	}
 
 	sink.Flush()
-	time.Sleep(time.Second * 5)
+	time.Sleep(2001 * time.Millisecond)
 
 	exp := strings.Join(expected[:], "")
 	buf := ts.String()

--- a/net_sink_test.go
+++ b/net_sink_test.go
@@ -886,7 +886,7 @@ func TestBatchingForTCP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to set GOSTATS_BATCH_SIZE environment variable: %s", err)
 	}
-	err = os.Setenv("GOSTATS_BATCH_SEND_INTERVAL_SECONDS", "100000") // effectively disable batch send interval
+	err = os.Setenv("GOSTATS_BATCH_SEND_INTERVAL_SECONDS", "5")
 	if err != nil {
 		t.Fatalf("Failed to set GOSTATS_BATCH_SEND_INTERVAL_SECONDS environment variable: %s", err)
 	}
@@ -901,14 +901,14 @@ func TestBatchingForTCP(t *testing.T) {
 		sink.FlushTimer("timer_int", float64(i%10))
 	}
 
-	time.Sleep(2001 * time.Millisecond)
+	sink.Flush() // force drain all remaining outc
+
+	// we send the batch ~every 5 seconds
+	time.Sleep(3001 * time.Millisecond)
 	if ts.String() != "" {
 		t.Errorf("Stats were written despite forced batching")
 	}
-
-	sink.Flush() // drain all outc and send
-
-	time.Sleep(1000 * time.Millisecond)
+	time.Sleep(3000 * time.Millisecond)
 
 	bufferSize := len(ts.String())
 	if bufferSize != expected {
@@ -929,7 +929,7 @@ func TestBatchingForUDP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to set GOSTATS_BATCH_SIZE environment variable: %s", err)
 	}
-	err = os.Setenv("GOSTATS_BATCH_SEND_INTERVAL_SECONDS", "100000") // effectively disable batch send interval
+	err = os.Setenv("GOSTATS_BATCH_SEND_INTERVAL_SECONDS", "5")
 	if err != nil {
 		t.Fatalf("Failed to set GOSTATS_BATCH_SEND_INTERVAL_SECONDS environment variable: %s", err)
 	}
@@ -944,14 +944,14 @@ func TestBatchingForUDP(t *testing.T) {
 		sink.FlushTimer("timer_int", float64(i%10))
 	}
 
-	time.Sleep(2001 * time.Millisecond)
+	sink.Flush() // force drain all remaining outc
+
+	// we send the batch ~every 5 seconds
+	time.Sleep(3001 * time.Millisecond)
 	if ts.String() != "" {
 		t.Errorf("Stats were written despite forced batching")
 	}
-
-	sink.Flush() // drain all outc and send
-
-	time.Sleep(1000 * time.Millisecond)
+	time.Sleep(3000 * time.Millisecond)
 
 	bufferSize := len(ts.String())
 	if bufferSize != expected {
@@ -963,7 +963,7 @@ func TestBatchingForUDP(t *testing.T) {
 	os.Unsetenv("GOSTATS_BATCH_SEND_INTERVAL_SECONDS")
 }
 
-func TestBatchingAutoSendWhenBatchIsFull(t *testing.T) {
+func TestBatchingSendWhenBatchIsFull(t *testing.T) {
 	err := os.Setenv("GOSTATS_BATCH_ENABLED", "true")
 	if err != nil {
 		t.Fatalf("Failed to set GOSTATS_BATCH_ENABLED environment variable: %s", err)
@@ -986,42 +986,7 @@ func TestBatchingAutoSendWhenBatchIsFull(t *testing.T) {
 		sink.FlushTimer("timer_int", float64(i%10))
 	}
 
-	time.Sleep(2001 * time.Millisecond) // we only flush to outc ~every second but the batch will be sent ~immediately as it's always full
-
-	bufferSize := len(ts.String())
-	if bufferSize != expected {
-		t.Errorf("Not all stats were written\ngot buffer size:\n%d\nwanted:\n%d\n", bufferSize, expected)
-	}
-
-	os.Unsetenv("GOSTATS_BATCH_ENABLED")
-	os.Unsetenv("GOSTATS_BATCH_SIZE")
-	os.Unsetenv("GOSTATS_BATCH_SEND_INTERVAL_SECONDS")
-}
-
-func TestBatchingAutoSendOnInterval(t *testing.T) {
-	err := os.Setenv("GOSTATS_BATCH_ENABLED", "true")
-	if err != nil {
-		t.Fatalf("Failed to set GOSTATS_BATCH_ENABLED environment variable: %s", err)
-	}
-	err = os.Setenv("GOSTATS_BATCH_SIZE", "10000")
-	if err != nil {
-		t.Fatalf("Failed to set GOSTATS_BATCH_SIZE environment variable: %s", err)
-	}
-	err = os.Setenv("GOSTATS_BATCH_SEND_INTERVAL_SECONDS", "2") // effectively disable batch send interval
-	if err != nil {
-		t.Fatalf("Failed to set GOSTATS_BATCH_SEND_INTERVAL_SECONDS environment variable: %s", err)
-	}
-
-	expected := 3840
-
-	ts, sink := setupTestNetSink(t, "tcp", false)
-	defer ts.Close()
-
-	for i := 0; i < 256; i++ {
-		sink.FlushTimer("timer_int", float64(i%10))
-	}
-
-	time.Sleep(3001 * time.Millisecond) // we only flush to outc ~every second and send the batch ~every 2 seconds
+	time.Sleep(2001 * time.Millisecond) // we flush to outc ~every second but the batch will be sent ~immediately as it's always full
 
 	bufferSize := len(ts.String())
 	if bufferSize != expected {

--- a/net_sink_test.go
+++ b/net_sink_test.go
@@ -848,7 +848,7 @@ func testNetSinkIntegration(t *testing.T, protocol string) {
 }
 
 func TestFlushTimerNoBatching(t *testing.T) {
-	err := os.Setenv("GOSTATS_FORCED_BATCHING", "false")
+	err := os.Setenv("GOSTATS_BATCH_SIZE", "0")
 	if err != nil {
 		t.Fatalf("Failed to set environment variable: %s", err)
 	}
@@ -858,7 +858,7 @@ func TestFlushTimerNoBatching(t *testing.T) {
 		"timer_float:1.230000|ms\n",
 	}
 
-	ts, sink := setupTestNetSink(t, "tcp", false) // the protocol is arbitrary and unimportant for batching
+	ts, sink := setupTestNetSink(t, "tcp", false)
 	defer ts.Close()
 
 	sink.FlushTimer("timer_int", 1)
@@ -872,11 +872,11 @@ func TestFlushTimerNoBatching(t *testing.T) {
 		t.Errorf("Not all stats were written\ngot:\n%q\nwant:\n%q\n", buf, exp)
 	}
 
-	os.Unsetenv("GOSTATS_FORCED_BATCHING")
+	os.Unsetenv("GOSTATS_BATCH_SIZE")
 }
 
-func TestFlushTimerBatching(t *testing.T) {
-	err := os.Setenv("GOSTATS_FORCED_BATCHING", "true")
+func TestFlushTimerBatchingForTCP(t *testing.T) {
+	err := os.Setenv("GOSTATS_BATCH_SIZE", "64")
 	if err != nil {
 		t.Fatalf("Failed to set environment variable: %s", err)
 	}
@@ -886,7 +886,7 @@ func TestFlushTimerBatching(t *testing.T) {
 		"timer_float:1.230000|ms\n",
 	}
 
-	ts, sink := setupTestNetSink(t, "tcp", false) // the protocol is arbitrary and unimportant for batching
+	ts, sink := setupTestNetSink(t, "tcp", false)
 	defer ts.Close()
 
 	sink.FlushTimer("timer_int", 1)
@@ -906,7 +906,41 @@ func TestFlushTimerBatching(t *testing.T) {
 		t.Errorf("Not all stats were written\ngot:\n%q\nwant:\n%q\n", buf, exp)
 	}
 
-	os.Unsetenv("GOSTATS_FORCED_BATCHING")
+	os.Unsetenv("GOSTATS_BATCH_SIZE")
+}
+
+func TestFlushTimerBatchingForUDP(t *testing.T) {
+	err := os.Setenv("GOSTATS_BATCH_SIZE", "2928")
+	if err != nil {
+		t.Fatalf("Failed to set environment variable: %s", err)
+	}
+
+	expected := [...]string{
+		"timer_int:1|ms\n",
+		"timer_float:1.230000|ms\n",
+	}
+
+	ts, sink := setupTestNetSink(t, "udp", false)
+	defer ts.Close()
+
+	sink.FlushTimer("timer_int", 1)
+	sink.FlushTimer("timer_float", 1.23)
+	time.Sleep(2001 * time.Millisecond)
+
+	if ts.String() != "" {
+		t.Errorf("Stats were written despite forced batching")
+	}
+
+	sink.Flush()
+	time.Sleep(2001 * time.Millisecond)
+
+	exp := strings.Join(expected[:], "")
+	buf := ts.String()
+	if buf != exp {
+		t.Errorf("Not all stats were written\ngot:\n%q\nwant:\n%q\n", buf, exp)
+	}
+
+	os.Unsetenv("GOSTATS_BATCH_SIZE")
 }
 
 func TestNetSink_Integration_TCP(t *testing.T) {

--- a/net_util_test.go
+++ b/net_util_test.go
@@ -347,7 +347,7 @@ func (m *errorCon) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
-func (m *errorCon) Read(b []byte) (int, error) {
+func (m *errorCon) Read(_ []byte) (int, error) {
 	return 0, io.EOF
 }
 
@@ -355,7 +355,7 @@ func (m *errorCon) Close() error {
 	return nil
 }
 
-func (m *errorCon) SetWriteDeadline(t time.Time) error {
+func (m *errorCon) SetWriteDeadline(_ time.Time) error {
 	return nil
 }
 
@@ -367,11 +367,11 @@ func (m *errorCon) RemoteAddr() net.Addr {
 	return &net.TCPAddr{}
 }
 
-func (m *errorCon) SetDeadline(t time.Time) error {
+func (m *errorCon) SetDeadline(_ time.Time) error {
 	return nil
 }
 
-func (m *errorCon) SetReadDeadline(t time.Time) error {
+func (m *errorCon) SetReadDeadline(_ time.Time) error {
 	return nil
 }
 

--- a/net_util_test.go
+++ b/net_util_test.go
@@ -332,6 +332,61 @@ func (s *netTestSink) CommandEnv(t testing.TB) []string {
 	)
 }
 
+type errorCon struct {
+	writes          [][]byte
+	writeErrorAfter int
+	writeCount      int
+}
+
+func (m *errorCon) Write(b []byte) (int, error) {
+	if m.writeErrorAfter > 0 && m.writeCount >= m.writeErrorAfter {
+		return 0, fmt.Errorf("mock write error")
+	}
+	m.writes = append(m.writes, b)
+	m.writeCount++
+	return len(b), nil
+}
+
+func (m *errorCon) Read(b []byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (m *errorCon) Close() error {
+	return nil
+}
+
+func (m *errorCon) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+func (m *errorCon) LocalAddr() net.Addr {
+	return &net.TCPAddr{}
+}
+
+func (m *errorCon) RemoteAddr() net.Addr {
+	return &net.TCPAddr{}
+}
+
+func (m *errorCon) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (m *errorCon) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func newErrorSink(errorAfter int) (*netSink, *errorCon) {
+	mockedConn := &errorCon{
+		writeErrorAfter: errorAfter,
+	}
+	sink := &netSink{
+		conn:   mockedConn,
+		retryc: make(chan *bytes.Buffer, 1),
+	}
+
+	return sink, mockedConn
+}
+
 func reconnectRetry(t testing.TB, fn func() error) {
 	const (
 		Retry   = time.Second / 4

--- a/settings.go
+++ b/settings.go
@@ -20,8 +20,12 @@ const (
 	DefaultFlushIntervalS = 5
 	// DefaultLoggingSinkDisabled is the default behavior of logging sink suppression, default is false.
 	DefaultLoggingSinkDisabled = false
-	// DefaultBatchSize is the default maximum amount of stats we batch before sending, default is 0 which disables batching.
-	DefaultBatchSize = 0
+	// DefaultBatchEnabled indicates whether batching should be enabled be default, batching is disabled by default.
+	DefaultBatchEnabled = false
+	// DefaultBatchSize is the default maximum number of stats to batch before sending, when batching is enabled.
+	DefaultBatchSize = 100
+	// DefaultBatchSendIntervalS is the default timeout to send the batch when batching is enabled, default is 5 to interleave DefaultFlushIntervalS.
+	DefaultBatchSendIntervalS = 5
 )
 
 // The Settings type is used to configure gostats. gostats uses environment
@@ -40,8 +44,15 @@ type Settings struct {
 	// Disable the LoggingSink when USE_STATSD is false and use the NullSink instead.
 	// This will cause all stats to be silently dropped.
 	LoggingSinkDisabled bool `envconfig:"GOSTATS_LOGGING_SINK_DISABLED" default:"false"`
-	// Max stats we batch before sending. 0 is disabled.
-	BatchSize int `envconfig:"GOSTATS_BATCH_SIZE" default:"0"`
+	// Enable batching stats to reduce intermittent sends.
+	BatchEnabled bool `envconfig:"GOSTATS_BATCH_ENABLED" default:"false"`
+	// Maximum number of stats to batch before sending.
+	// For UDP, despite this configuration, stats will naturally be distributed over multiple packets, single stats are guarenteed to fit in 1 packet but we will still fragment the batch.
+	// Depends on BatchEnabled.
+	BatchSize int `envconfig:"GOSTATS_BATCH_SIZE" default:"100"`
+	// Fallback timeout to send the batch.
+	// Depends on BatchEnabled.
+	BatchSendIntervalS int `envconfig:"GOSTATS_BATCH_SEND_INTERVAL_SECONDS" default:"5"`
 }
 
 // An envError is an error that occurred parsing an environment variable
@@ -105,7 +116,15 @@ func GetSettings() Settings {
 	if err != nil {
 		panic(err)
 	}
+	batchEnabled, err := envBool("GOSTATS_BATCH_ENABLED", DefaultBatchEnabled)
+	if err != nil {
+		panic(err)
+	}
 	batchSize, err := envInt("GOSTATS_BATCH_SIZE", DefaultBatchSize)
+	if err != nil {
+		panic(err)
+	}
+	batchSendIntervalS, err := envInt("GOSTATS_BATCH_SEND_INTERVAL_SECONDS", DefaultBatchSendIntervalS)
 	if err != nil {
 		panic(err)
 	}
@@ -116,7 +135,9 @@ func GetSettings() Settings {
 		StatsdPort:          statsdPort,
 		FlushIntervalS:      flushIntervalS,
 		LoggingSinkDisabled: loggingSinkDisabled,
+		BatchEnabled:        batchEnabled,
 		BatchSize:           batchSize,
+		BatchSendIntervalS:  batchSendIntervalS,
 	}
 }
 

--- a/settings.go
+++ b/settings.go
@@ -105,7 +105,7 @@ func GetSettings() Settings {
 	if err != nil {
 		panic(err)
 	}
-	delayedFlush, err := envInt("GOSTATS_DELAYED_FLUSH", DefaultDelayedFlush)
+	delayedFlush, err := envBool("GOSTATS_DELAYED_FLUSH", DefaultDelayedFlush)
 	if err != nil {
 		panic(err)
 	}

--- a/settings.go
+++ b/settings.go
@@ -20,8 +20,8 @@ const (
 	DefaultFlushIntervalS = 5
 	// DefaultLoggingSinkDisabled is the default behavior of logging sink suppression, default is false.
 	DefaultLoggingSinkDisabled = false
-	// DefaultDelayedFlush defines if we want to force batching by default
-	DefaultDelayedFlush = false
+	// DefaultForcedBatching defines if we want to force batching by default
+	DefaultForcedBatching = false
 )
 
 // The Settings type is used to configure gostats. gostats uses environment
@@ -41,7 +41,7 @@ type Settings struct {
 	// This will cause all stats to be silently dropped.
 	LoggingSinkDisabled bool `envconfig:"GOSTATS_LOGGING_SINK_DISABLED" default:"false"`
 	// Force batching under FlushIntervalS for all metrics
-	DelayedFlush bool `envconfig:"GOSTATS_DELAYED_FLUSH" default:"false"`
+	ForcedBatching bool `envconfig:"GOSTATS_FORCED_BATCHING" default:"false"`
 }
 
 // An envError is an error that occurred parsing an environment variable
@@ -105,7 +105,7 @@ func GetSettings() Settings {
 	if err != nil {
 		panic(err)
 	}
-	delayedFlush, err := envBool("GOSTATS_DELAYED_FLUSH", DefaultDelayedFlush)
+	forcedBatching, err := envBool("GOSTATS_FORCED_BATCHING", DefaultForcedBatching)
 	if err != nil {
 		panic(err)
 	}
@@ -116,7 +116,7 @@ func GetSettings() Settings {
 		StatsdPort:          statsdPort,
 		FlushIntervalS:      flushIntervalS,
 		LoggingSinkDisabled: loggingSinkDisabled,
-		DelayedFlush:        delayedFlush,
+		ForcedBatching:      forcedBatching,
 	}
 }
 

--- a/settings.go
+++ b/settings.go
@@ -20,6 +20,8 @@ const (
 	DefaultFlushIntervalS = 5
 	// DefaultLoggingSinkDisabled is the default behavior of logging sink suppression, default is false.
 	DefaultLoggingSinkDisabled = false
+	// DefaultDelayedFlush defines if we want to force batching by default
+	DefaultDelayedFlush = false
 )
 
 // The Settings type is used to configure gostats. gostats uses environment
@@ -38,6 +40,8 @@ type Settings struct {
 	// Disable the LoggingSink when USE_STATSD is false and use the NullSink instead.
 	// This will cause all stats to be silently dropped.
 	LoggingSinkDisabled bool `envconfig:"GOSTATS_LOGGING_SINK_DISABLED" default:"false"`
+	// Force batching under FlushIntervalS for all metrics
+	DelayedFlush bool `envconfig:"GOSTATS_DELAYED_FLUSH" default:"false"`
 }
 
 // An envError is an error that occurred parsing an environment variable
@@ -101,6 +105,10 @@ func GetSettings() Settings {
 	if err != nil {
 		panic(err)
 	}
+	delayedFlush, err := envInt("GOSTATS_DELAYED_FLUSH", DefaultDelayedFlush)
+	if err != nil {
+		panic(err)
+	}
 	return Settings{
 		UseStatsd:           useStatsd,
 		StatsdHost:          envOr("STATSD_HOST", DefaultStatsdHost),
@@ -108,6 +116,7 @@ func GetSettings() Settings {
 		StatsdPort:          statsdPort,
 		FlushIntervalS:      flushIntervalS,
 		LoggingSinkDisabled: loggingSinkDisabled,
+		DelayedFlush:        delayedFlush,
 	}
 }
 

--- a/settings.go
+++ b/settings.go
@@ -47,7 +47,7 @@ type Settings struct {
 	// Enable batching stats to reduce intermittent sends.
 	BatchEnabled bool `envconfig:"GOSTATS_BATCH_ENABLED" default:"false"`
 	// Maximum number of stats to batch before sending.
-	// For UDP, despite this configuration, stats will naturally be distributed over multiple packets, single stats are guarenteed to fit in 1 packet but we will still fragment the batch.
+	// For UDP, despite this configuration, stats will naturally be distributed over multiple packets, single stats are guaranteed to fit in 1 packet but we will still fragment the batch.
 	// Depends on BatchEnabled.
 	BatchSize int `envconfig:"GOSTATS_BATCH_SIZE" default:"100"`
 	// Fallback timeout to send the batch.

--- a/settings.go
+++ b/settings.go
@@ -20,7 +20,7 @@ const (
 	DefaultFlushIntervalS = 5
 	// DefaultLoggingSinkDisabled is the default behavior of logging sink suppression, default is false.
 	DefaultLoggingSinkDisabled = false
-	// DefaultBatchSize implies if batching is enabled by default and the amount to batch
+	// DefaultBatchSize is the default maximum amount of stats we batch before sending, default is 0 which disables batching.
 	DefaultBatchSize = 0
 )
 
@@ -40,7 +40,7 @@ type Settings struct {
 	// Disable the LoggingSink when USE_STATSD is false and use the NullSink instead.
 	// This will cause all stats to be silently dropped.
 	LoggingSinkDisabled bool `envconfig:"GOSTATS_LOGGING_SINK_DISABLED" default:"false"`
-	// Amount of stats to batch before sending. 0 is disabled.
+	// Max stats we batch before sending. 0 is disabled.
 	BatchSize int `envconfig:"GOSTATS_BATCH_SIZE" default:"0"`
 }
 

--- a/settings.go
+++ b/settings.go
@@ -20,8 +20,8 @@ const (
 	DefaultFlushIntervalS = 5
 	// DefaultLoggingSinkDisabled is the default behavior of logging sink suppression, default is false.
 	DefaultLoggingSinkDisabled = false
-	// DefaultForcedBatching defines if we want to force batching by default
-	DefaultForcedBatching = false
+	// DefaultBatchSize implies if batching is enabled by default and the amount to batch
+	DefaultBatchSize = 0
 )
 
 // The Settings type is used to configure gostats. gostats uses environment
@@ -40,8 +40,8 @@ type Settings struct {
 	// Disable the LoggingSink when USE_STATSD is false and use the NullSink instead.
 	// This will cause all stats to be silently dropped.
 	LoggingSinkDisabled bool `envconfig:"GOSTATS_LOGGING_SINK_DISABLED" default:"false"`
-	// Force batching under FlushIntervalS for all metrics
-	ForcedBatching bool `envconfig:"GOSTATS_FORCED_BATCHING" default:"false"`
+	// Amount of stats to batch before sending. 0 is disabled.
+	BatchSize int `envconfig:"GOSTATS_BATCH_SIZE" default:"0"`
 }
 
 // An envError is an error that occurred parsing an environment variable
@@ -105,7 +105,7 @@ func GetSettings() Settings {
 	if err != nil {
 		panic(err)
 	}
-	forcedBatching, err := envBool("GOSTATS_FORCED_BATCHING", DefaultForcedBatching)
+	batchSize, err := envInt("GOSTATS_BATCH_SIZE", DefaultBatchSize)
 	if err != nil {
 		panic(err)
 	}
@@ -116,7 +116,7 @@ func GetSettings() Settings {
 		StatsdPort:          statsdPort,
 		FlushIntervalS:      flushIntervalS,
 		LoggingSinkDisabled: loggingSinkDisabled,
-		ForcedBatching:      forcedBatching,
+		BatchSize:           batchSize,
 	}
 }
 

--- a/settings_test.go
+++ b/settings_test.go
@@ -46,6 +46,9 @@ func TestSettingsCompat(t *testing.T) {
 		"STATSD_PORT", "",
 		"GOSTATS_FLUSH_INTERVAL_SECONDS", "",
 		"GOSTATS_LOGGING_SINK_DISABLED", "",
+		"GOSTATS_BATCH_ENABLED", "",
+		"GOSTATS_BATCH_SIZE", "",
+		"GOSTATS_BATCH_SEND_INTERVAL_SECONDS", "",
 	)
 	defer reset()
 
@@ -68,6 +71,9 @@ func TestSettingsDefault(t *testing.T) {
 		"STATSD_PORT", "",
 		"GOSTATS_FLUSH_INTERVAL_SECONDS", "",
 		"GOSTATS_LOGGING_SINK_DISABLED", "",
+		"GOSTATS_BATCH_ENABLED", "",
+		"GOSTATS_BATCH_SIZE", "",
+		"GOSTATS_BATCH_SEND_INTERVAL_SECONDS", "",
 	)
 	defer reset()
 	exp := Settings{
@@ -77,6 +83,9 @@ func TestSettingsDefault(t *testing.T) {
 		StatsdPort:          DefaultStatsdPort,
 		FlushIntervalS:      DefaultFlushIntervalS,
 		LoggingSinkDisabled: DefaultLoggingSinkDisabled,
+		BatchEnabled:        DefaultBatchEnabled,
+		BatchSize:           DefaultBatchSize,
+		BatchSendIntervalS:  DefaultBatchSendIntervalS,
 	}
 	settings := GetSettings()
 	if exp != settings {
@@ -92,6 +101,9 @@ func TestSettingsOverride(t *testing.T) {
 		"STATSD_PORT", "1234",
 		"GOSTATS_FLUSH_INTERVAL_SECONDS", "3",
 		"GOSTATS_LOGGING_SINK_DISABLED", "true",
+		"GOSTATS_BATCH_ENABLED", "true",
+		"GOSTATS_BATCH_SIZE", "200",
+		"GOSTATS_BATCH_SEND_INTERVAL_SECONDS", "10",
 	)
 	defer reset()
 	exp := Settings{
@@ -101,6 +113,9 @@ func TestSettingsOverride(t *testing.T) {
 		StatsdPort:          1234,
 		FlushIntervalS:      3,
 		LoggingSinkDisabled: true,
+		BatchEnabled:        true,
+		BatchSize:           200,
+		BatchSendIntervalS:  10,
 	}
 	settings := GetSettings()
 	if exp != settings {
@@ -112,10 +127,13 @@ func TestSettingsErrors(t *testing.T) {
 	// STATSD_HOST doesn't error so we don't check it
 
 	tests := map[string]string{
-		"USE_STATSD":                     "FOO!",
-		"STATSD_PORT":                    "not-an-int",
-		"GOSTATS_FLUSH_INTERVAL_SECONDS": "true",
-		"GOSTATS_LOGGING_SINK_DISABLED":  "1337",
+		"USE_STATSD":                          "FOO!",
+		"STATSD_PORT":                         "not-an-int",
+		"GOSTATS_FLUSH_INTERVAL_SECONDS":      "true",
+		"GOSTATS_LOGGING_SINK_DISABLED":       "1337",
+		"GOSTATS_BATCH_ENABLED":               "2",
+		"GOSTATS_BATCH_SIZE":                  "true",
+		"GOSTATS_BATCH_SEND_INTERVAL_SECONDS": "false",
 	}
 	for key, val := range tests {
 		t.Run(key, func(t *testing.T) {

--- a/stats.go
+++ b/stats.go
@@ -397,7 +397,7 @@ func (s *statStore) Flush() {
 
 	flushableSink, ok := s.sink.(FlushableSink)
 	if ok {
-		flushableSink.Flush() // flushes everything buffered to a channel (outc) and specifies outc to be drained to either a batch or sent immediatly
+		flushableSink.Flush() // flushes everything buffered to a channel (outc) and specifies outc to be drained to either a batch or sent immediately
 	}
 }
 

--- a/stats.go
+++ b/stats.go
@@ -313,7 +313,7 @@ func (t *timer) AddDuration(dur time.Duration) {
 }
 
 func (t *timer) AddValue(value float64) {
-	t.sink.FlushTimer(t.name, value) // writes the timer to a buffered channel which will send immediately unless GOSTATS_DELAYED_FLUSH is set
+	t.sink.FlushTimer(t.name, value) // writes the timer to a buffered channel which will send immediately unless GOSTATS_FORCED_BATCHING is set
 }
 
 func (t *timer) AllocateSpan() Timespan {
@@ -384,13 +384,13 @@ func (s *statStore) Flush() {
 	s.counters.Range(func(key, v interface{}) bool {
 		// do not flush counters that are set to zero
 		if value := v.(*counter).latch(); value != 0 {
-			s.sink.FlushCounter(key.(string), value) // writes the counter to a buffered channel which will be sent either right away or at the end of the stack depending on GOSTATS_DELAYED_FLUSH
+			s.sink.FlushCounter(key.(string), value) // writes the counter to a buffered channel which will be sent either right away or at the end of the stack depending on GOSTATS_FORCED_BATCHING
 		}
 		return true
 	})
 
 	s.gauges.Range(func(key, v interface{}) bool {
-		s.sink.FlushGauge(key.(string), v.(*gauge).Value()) // writes the gauage to a buffered channel which will be sent either right away or at the end of the stack depending on GOSTATS_DELAYED_FLUSH
+		s.sink.FlushGauge(key.(string), v.(*gauge).Value()) // writes the gauage to a buffered channel which will be sent either right away or at the end of the stack depending on GOSTATS_FORCED_BATCHING
 		return true
 	})
 

--- a/stats.go
+++ b/stats.go
@@ -357,7 +357,7 @@ func (s *statStore) validateTags(tags map[string]string) {
 	}
 }
 
-// buffer stats loop (force flushing once per stack) on the specified ticker
+// buffer stats loop (forced flushing the buffer and sending all once per itteration) on the specified ticker
 func (s *statStore) StartContext(ctx context.Context, ticker *time.Ticker) {
 	for {
 		select {
@@ -396,7 +396,7 @@ func (s *statStore) Flush() {
 
 	flushableSink, ok := s.sink.(FlushableSink)
 	if ok {
-		flushableSink.Flush() // flushes buffer to outc which sends immediately if batching is disabled, also signals doFlush to send batched outc data if batching is enabaled
+		flushableSink.Flush() // flushes buffer to outc which starts sending immediately if batching is disabled, also signals doFlush to send batched outc data if batching is enabaled
 	}
 }
 

--- a/stats.go
+++ b/stats.go
@@ -313,7 +313,7 @@ func (t *timer) AddDuration(dur time.Duration) {
 }
 
 func (t *timer) AddValue(value float64) {
-	t.sink.FlushTimer(t.name, value)
+	t.sink.FlushTimer(t.name, value) // writes the timer to buffer channel and send immediately unless DELAY_FLUSH is set
 }
 
 func (t *timer) AllocateSpan() Timespan {
@@ -357,6 +357,7 @@ func (s *statStore) validateTags(tags map[string]string) {
 	}
 }
 
+// flush loop based on specified ticker
 func (s *statStore) StartContext(ctx context.Context, ticker *time.Ticker) {
 	for {
 		select {
@@ -383,19 +384,19 @@ func (s *statStore) Flush() {
 	s.counters.Range(func(key, v interface{}) bool {
 		// do not flush counters that are set to zero
 		if value := v.(*counter).latch(); value != 0 {
-			s.sink.FlushCounter(key.(string), value)
+			s.sink.FlushCounter(key.(string), value) // writes the counter to buffer channel which will send immediately unless DELAY_FLUSH is set
 		}
 		return true
 	})
 
 	s.gauges.Range(func(key, v interface{}) bool {
-		s.sink.FlushGauge(key.(string), v.(*gauge).Value())
+		s.sink.FlushGauge(key.(string), v.(*gauge).Value()) // writes the gauage to buffer channel which will send immediately unless DELAY_FLUSH is set
 		return true
 	})
 
 	flushableSink, ok := s.sink.(FlushableSink)
 	if ok {
-		flushableSink.Flush()
+		flushableSink.Flush() // signal counters, gauges and timers (i.e. buffer channel to be drained) to be sent if not sent immediately
 	}
 }
 

--- a/stats.go
+++ b/stats.go
@@ -313,7 +313,7 @@ func (t *timer) AddDuration(dur time.Duration) {
 }
 
 func (t *timer) AddValue(value float64) {
-	t.sink.FlushTimer(t.name, value) // writes the timer value to the buffer which will be flushed to outc every second, will be sent immediately when flushed to outc is batching is not enabeld
+	t.sink.FlushTimer(t.name, value) // writes the timer value to a buffer which will be flushed to outc at an interval, will be sent immediately when flushed to outc if batching is not enabeld
 }
 
 func (t *timer) AllocateSpan() Timespan {
@@ -357,7 +357,7 @@ func (s *statStore) validateTags(tags map[string]string) {
 	}
 }
 
-// stat buffer and flush loop based on specified ticker
+// stat buffer and flush loop based on the specified ticker
 func (s *statStore) StartContext(ctx context.Context, ticker *time.Ticker) {
 	for {
 		select {
@@ -384,19 +384,19 @@ func (s *statStore) Flush() {
 	s.counters.Range(func(key, v interface{}) bool {
 		// do not flush counters that are set to zero
 		if value := v.(*counter).latch(); value != 0 {
-			s.sink.FlushCounter(key.(string), value) // writes counters to buffer which will be flushed to both outc every second and at the end of this stack
+			s.sink.FlushCounter(key.(string), value) // writes counters to a buffer which will be flushed to outc both at an interval and at the end of this stack
 		}
 		return true
 	})
 
 	s.gauges.Range(func(key, v interface{}) bool {
-		s.sink.FlushGauge(key.(string), v.(*gauge).Value()) // writes gauages to buffer which will be flushed to outc both every second and at the end of this stack
+		s.sink.FlushGauge(key.(string), v.(*gauge).Value()) // writes gauages to a buffer which will be flushed to outc both at an interval and at the end of this stack
 		return true
 	})
 
 	flushableSink, ok := s.sink.(FlushableSink)
 	if ok {
-		flushableSink.Flush() // flushes buffer to outc which directly writes if batching is disabled and signals doFlush to send outc data if batching is enabaled
+		flushableSink.Flush() // flushes buffer to outc which sends immediately if batching is disabled, also signals doFlush to send batched outc data if batching is enabaled
 	}
 }
 

--- a/stats.go
+++ b/stats.go
@@ -357,7 +357,7 @@ func (s *statStore) validateTags(tags map[string]string) {
 	}
 }
 
-// stat buffer and flush loop based on the specified ticker
+// buffer stats loop (force flushing once per stack) on the specified ticker
 func (s *statStore) StartContext(ctx context.Context, ticker *time.Ticker) {
 	for {
 		select {

--- a/stats.go
+++ b/stats.go
@@ -313,7 +313,7 @@ func (t *timer) AddDuration(dur time.Duration) {
 }
 
 func (t *timer) AddValue(value float64) {
-	t.sink.FlushTimer(t.name, value) // writes the timer to buffer channel and send immediately unless DELAY_FLUSH is set
+	t.sink.FlushTimer(t.name, value) // writes the timer to a buffered channel which will send immediately unless GOSTATS_DELAYED_FLUSH is set
 }
 
 func (t *timer) AllocateSpan() Timespan {
@@ -384,19 +384,19 @@ func (s *statStore) Flush() {
 	s.counters.Range(func(key, v interface{}) bool {
 		// do not flush counters that are set to zero
 		if value := v.(*counter).latch(); value != 0 {
-			s.sink.FlushCounter(key.(string), value) // writes the counter to buffer channel which will send immediately unless DELAY_FLUSH is set
+			s.sink.FlushCounter(key.(string), value) // writes the counter to a buffered channel which will be sent either right away or at the end of the stack depending on GOSTATS_DELAYED_FLUSH
 		}
 		return true
 	})
 
 	s.gauges.Range(func(key, v interface{}) bool {
-		s.sink.FlushGauge(key.(string), v.(*gauge).Value()) // writes the gauage to buffer channel which will send immediately unless DELAY_FLUSH is set
+		s.sink.FlushGauge(key.(string), v.(*gauge).Value()) // writes the gauage to a buffered channel which will be sent either right away or at the end of the stack depending on GOSTATS_DELAYED_FLUSH
 		return true
 	})
 
 	flushableSink, ok := s.sink.(FlushableSink)
 	if ok {
-		flushableSink.Flush() // signal counters, gauges and timers (i.e. buffer channel to be drained) to be sent if not sent immediately
+		flushableSink.Flush() // signal the buffered channel (buffered counters, gauges and timers) to be drained and sent if there is anythig to send
 	}
 }
 

--- a/stats.go
+++ b/stats.go
@@ -313,7 +313,7 @@ func (t *timer) AddDuration(dur time.Duration) {
 }
 
 func (t *timer) AddValue(value float64) {
-	t.sink.FlushTimer(t.name, value) // writes the timer to a buffered channel which will send immediately unless GOSTATS_FORCED_BATCHING is set
+	t.sink.FlushTimer(t.name, value) // writes the timer value to the buffer which will be flushed to outc every second, will be sent immediately when flushed to outc is batching is not enabeld
 }
 
 func (t *timer) AllocateSpan() Timespan {
@@ -357,7 +357,7 @@ func (s *statStore) validateTags(tags map[string]string) {
 	}
 }
 
-// flush loop based on specified ticker
+// stat buffer and flush loop based on specified ticker
 func (s *statStore) StartContext(ctx context.Context, ticker *time.Ticker) {
 	for {
 		select {
@@ -384,19 +384,19 @@ func (s *statStore) Flush() {
 	s.counters.Range(func(key, v interface{}) bool {
 		// do not flush counters that are set to zero
 		if value := v.(*counter).latch(); value != 0 {
-			s.sink.FlushCounter(key.(string), value) // writes the counter to a buffered channel which will be sent either right away or at the end of the stack depending on GOSTATS_FORCED_BATCHING
+			s.sink.FlushCounter(key.(string), value) // writes counters to buffer which will be flushed to both outc every second and at the end of this stack
 		}
 		return true
 	})
 
 	s.gauges.Range(func(key, v interface{}) bool {
-		s.sink.FlushGauge(key.(string), v.(*gauge).Value()) // writes the gauage to a buffered channel which will be sent either right away or at the end of the stack depending on GOSTATS_FORCED_BATCHING
+		s.sink.FlushGauge(key.(string), v.(*gauge).Value()) // writes gauages to buffer which will be flushed to outc both every second and at the end of this stack
 		return true
 	})
 
 	flushableSink, ok := s.sink.(FlushableSink)
 	if ok {
-		flushableSink.Flush() // signal the buffered channel (buffered counters, gauges and timers) to be drained and sent if there is anythig to send
+		flushableSink.Flush() // flushes buffer to outc which directly writes if batching is disabled and signals doFlush to send outc data if batching is enabaled
 	}
 }
 

--- a/stats.go
+++ b/stats.go
@@ -313,7 +313,7 @@ func (t *timer) AddDuration(dur time.Duration) {
 }
 
 func (t *timer) AddValue(value float64) {
-	t.sink.FlushTimer(t.name, value) // writes the timer value to a buffer which will be flushed to outc at an interval, will be sent immediately when flushed to outc if batching is not enabeld
+	t.sink.FlushTimer(t.name, value) // writes the timer value to a buffer. this buffer will be flushed to a channel (outc) at an interval and from this channel either batched or sent directly
 }
 
 func (t *timer) AllocateSpan() Timespan {
@@ -357,7 +357,7 @@ func (s *statStore) validateTags(tags map[string]string) {
 	}
 }
 
-// buffer stats loop (forced flushing the buffer and sending all once per itteration) on the specified ticker
+// counter and gauage buffer and flush loop on the specified ticker
 func (s *statStore) StartContext(ctx context.Context, ticker *time.Ticker) {
 	for {
 		select {
@@ -374,6 +374,7 @@ func (s *statStore) Start(ticker *time.Ticker) {
 	s.StartContext(context.Background(), ticker)
 }
 
+// writes any stored counters and gauages to a buffer which will be flushed to a channel (outc) at an interval (in the outc send loop) or at the end of this stack
 func (s *statStore) Flush() {
 	s.mu.RLock()
 	for _, g := range s.statGenerators {
@@ -384,19 +385,19 @@ func (s *statStore) Flush() {
 	s.counters.Range(func(key, v interface{}) bool {
 		// do not flush counters that are set to zero
 		if value := v.(*counter).latch(); value != 0 {
-			s.sink.FlushCounter(key.(string), value) // writes counters to a buffer which will be flushed to outc both at an interval and at the end of this stack
+			s.sink.FlushCounter(key.(string), value)
 		}
 		return true
 	})
 
 	s.gauges.Range(func(key, v interface{}) bool {
-		s.sink.FlushGauge(key.(string), v.(*gauge).Value()) // writes gauages to a buffer which will be flushed to outc both at an interval and at the end of this stack
+		s.sink.FlushGauge(key.(string), v.(*gauge).Value())
 		return true
 	})
 
 	flushableSink, ok := s.sink.(FlushableSink)
 	if ok {
-		flushableSink.Flush() // flushes buffer to outc which starts sending immediately if batching is disabled, also signals doFlush to send batched outc data if batching is enabaled
+		flushableSink.Flush() // flushes everything buffered to a channel (outc) and specifies outc to be drained to either a batch or sent immediatly
 	}
 }
 

--- a/stats_test.go
+++ b/stats_test.go
@@ -78,9 +78,9 @@ func TestValidateTags(t *testing.T) {
 	store.Flush()
 
 	expected := "test:1|c"
-	counter := sink.record
-	if !strings.Contains(counter, expected) {
-		t.Error("wanted counter value of test:1|c, got", counter)
+	output := sink.record
+	if !strings.Contains(output, expected) && !strings.Contains(output, "reserved_tag") {
+		t.Errorf("Expected without reserved tags: '%s' Got: '%s'", expected, output)
 	}
 
 	// A reserved tag should trigger adding the reserved_tag counter
@@ -89,10 +89,11 @@ func TestValidateTags(t *testing.T) {
 	store.NewCounterWithTags("test", map[string]string{"host": "i"}).Inc()
 	store.Flush()
 
-	expected = "reserved_tag:1|c\ntest.__host=i:1|c"
-	counter = sink.record
-	if !strings.Contains(counter, expected) {
-		t.Error("wanted counter value of test.___f=i:1|c, got", counter)
+	expected = "test.__host=i:1|c"
+	expectedReservedTag := "reserved_tag:1|c"
+	output = sink.record
+	if !strings.Contains(output, expected) && !strings.Contains(output, expectedReservedTag) {
+		t.Errorf("Expected: '%s' and '%s', In: '%s'", expected, expectedReservedTag, output)
 	}
 }
 


### PR DESCRIPTION
Add more definite send interval control than what flush interval provided, restricting when any metrics is sent to this interval. This will implicitly introduce batching for timers.