### PR TITLE
test a increased stats flush interval

### DIFF
--- a/net_sink.go
+++ b/net_sink.go
@@ -27,7 +27,7 @@ const (
 	defaultDialTimeout   = defaultRetryInterval / 2
 	defaultWriteTimeout  = time.Second
 
-	flushInterval           = time.Second
+	flushInterval           = 2 * time.Second
 	logOnEveryNDroppedBytes = 1 << 15 // Log once per 32kb of dropped stats
 	defaultBufferSizeTCP    = 1 << 16
 

--- a/net_sink.go
+++ b/net_sink.go
@@ -29,7 +29,7 @@ const (
 
 	flushInterval           = 2 * time.Second
 	logOnEveryNDroppedBytes = 1 << 15 // Log once per 32kb of dropped stats
-	defaultBufferSizeTCP    = 1 << 16
+	defaultBufferSizeTCP    = 1 << 16 * 2
 
 	// 1432 bytes is optimal for regular networks with an MTU of 1500 and
 	// is to prevent fragmenting UDP datagrams
@@ -111,14 +111,17 @@ func NewNetSink(opts ...SinkOption) FlushableSink {
 	// Calculate buffer size based on protocol, for UDP we want to pick a
 	// buffer size that will prevent datagram fragmentation.
 	var bufSize int
+	var queueSize int
 	switch s.conf.StatsdProtocol {
 	case "udp", "udp4", "udp6":
 		bufSize = defaultBufferSizeUDP
+		queueSize = approxMaxMemBytes / bufSize
 	default:
 		bufSize = defaultBufferSizeTCP
+		queueSize = (approxMaxMemBytes * 2) / bufSize
 	}
 
-	s.outc = make(chan *bytes.Buffer, approxMaxMemBytes/bufSize)
+	s.outc = make(chan *bytes.Buffer, queueSize)
 	s.retryc = make(chan *bytes.Buffer, 1) // It should be okay to limit this given we preferentially process from this over outc.
 
 	writer := &sinkWriter{outc: s.outc}


### PR DESCRIPTION
We buffer stats over tcp up to ~65kb, and tmk this will be the max we can fit in a tcp packet. Increasing this buffer then will probably have no impact at least in regards to packets we send, however if we were to increase the interval this buffer is being flushed we may see less packets.

For heavy outflow cases, this buffer is probably already being filled (and under that flushed) before the set interval anyway so i'm not too optimistic for this case, but maybe i'm wrong and i think surely it should provide a positive influence for less heavy services.  

Maybe the downstreams can just handle stats better if they just arrive bunched up/even closer together?

Using this to see if an arbitrarily doubled flush interval and increased buffer size will have an impact on downstream cpu performance.

### **do not merge**