### PR TITLE
Use gauges instead of counters for GC Pause Total and Num GCs

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -76,7 +76,7 @@ func (r runtimeStats) GenerateStats() {
 
 	r.nextGC.Set(memStats.NextGC)
 	r.lastGC.Set(memStats.LastGC)
-	r.pauseTotalNs.Set(uint64(memStats.PauseTotalNs))
+	r.pauseTotalNs.Set(memStats.PauseTotalNs)
 	r.numGC.Set(uint64(memStats.NumGC))
 	r.gcCPUPercent.Set(uint64(memStats.GCCPUFraction * 100))
 

--- a/runtime.go
+++ b/runtime.go
@@ -23,8 +23,8 @@ type runtimeStats struct {
 	// Garbage collector statistics.
 	nextGC       Gauge // next collection will happen when HeapAlloc ≥ this amount
 	lastGC       Gauge // end time of last collection (nanoseconds since 1970)
-	pauseTotalNs Counter
-	numGC        Counter
+	pauseTotalNs Gauge
+	numGC        Gauge
 	gcCPUPercent Gauge
 
 	numGoroutine Gauge
@@ -50,8 +50,8 @@ func NewRuntimeStats(scope Scope) StatGenerator {
 
 		nextGC:       scope.NewGauge("nextGC"),
 		lastGC:       scope.NewGauge("lastGC"),
-		pauseTotalNs: scope.NewCounter("pauseTotalNs"),
-		numGC:        scope.NewCounter("numGC"),
+		pauseTotalNs: scope.NewGauge("pauseTotalNs"),
+		numGC:        scope.NewGauge("numGC"),
 		gcCPUPercent: scope.NewGauge("gcCPUPercent"),
 
 		numGoroutine: scope.NewGauge("numGoroutine"),
@@ -76,7 +76,7 @@ func (r runtimeStats) GenerateStats() {
 
 	r.nextGC.Set(memStats.NextGC)
 	r.lastGC.Set(memStats.LastGC)
-	r.pauseTotalNs.Set(memStats.PauseTotalNs)
+	r.pauseTotalNs.Set(uint64(memStats.PauseTotalNs))
 	r.numGC.Set(uint64(memStats.NumGC))
 	r.gcCPUPercent.Set(uint64(memStats.GCCPUFraction * 100))
 


### PR DESCRIPTION
First of a series of fixes to make the obs of Go runtime stats better: WIP doc https://docs.google.com/document/d/1qGNgOgRV1FEuMlXIy0vzEvKdqRXYlYLGONaI0czs5d8/edit?tab=t.0

First issue we found is a couple of counters that are being misused and leading to an unbounded increment and then being divided by itself leading to a 1 value all the time.

[Example with Etaproxy](https://grafana.lyft.net/explore?orgId=1&left=%5B%221747242878581%22,%221747248264826%22,%22m3%22,%7B%22datasource%22:%22m3%22,%22expr%22:%22production:app:etaproxy:go:numGC:count:sum%7Basg%3D%5C%22etaproxy%5C%22%7D%20%2F%20production:app:etaproxy:go:numGC:count:sum%7Basg%3D%5C%22etaproxy%5C%22%7D%22,%22interval%22:%2260s%22,%22intervalFactor%22:%22%22,%22legendFormat%22:%22%7B%7B%20facet%20%7D%7D%22,%22modified%22:%22true%22,%22exemplar%22:false,%22requestId%22:%22Q-d31d9f93-366a-455a-9856-4f6a941c7153-0A%22%7D%5D)


If you look at the 2 counters we are changing right now and check the units you can see how they are growing unbounded and why gauge might be better:

pauseTotalNs: https://alerts.lyft.net/chart_v2/c6u11FIXgf?qs=%7B%22t%22%3A%7B%22startTimeMs%22%3A1747242870566%2C%22endTimeMs%22%3A1747249917735%7D%2C%22s%22%3A%5B%5D%7D 

numGC: https://alerts.lyft.net/chart_v2/mTZNYUVfav?qs=%7B%22t%22%3A%7B%22startTimeMs%22%3A1747242881886%2C%22endTimeMs%22%3A1747249889433%7D%2C%22s%22%3A%5B%5D%7D 
