### PR TITLE
Add StoreOption/WithSinkWrap to expose the sink NewDefaultStore builds

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -219,17 +219,32 @@ func NewStore(sink Sink, _ bool) Store {
 
 // NewDefaultStore returns a Store with a TCP statsd sink, and a running flush timer.
 func NewDefaultStore() Store {
+	return NewDefaultStoreWithSink(func(sink FlushableSink) FlushableSink { return sink })
+}
+
+// NewDefaultStoreWithSink is like NewDefaultStore, but passes the sink it
+// would otherwise have used unwrapped (chosen from Settings exactly as
+// NewDefaultStore does: a TCP statsd sink, or a logging/null sink depending
+// on UseStatsd and LoggingSinkDisabled) through wrap first.
+//
+// This lets a caller decorate that sink -- for example to filter which
+// stats actually get flushed -- without having to reimplement
+// NewDefaultStore's sink-selection logic themselves just to get at the
+// underlying sink, which NewDefaultStore itself doesn't expose.
+func NewDefaultStoreWithSink(wrap func(FlushableSink) FlushableSink) Store {
 	var newStore Store
 	settings := GetSettings()
 	if !settings.UseStatsd {
+		var inner FlushableSink
 		if settings.LoggingSinkDisabled {
-			newStore = NewStore(NewNullSink(), false)
+			inner = NewNullSink()
 		} else {
-			newStore = NewStore(NewLoggingSink(), false)
+			inner = NewLoggingSink()
 		}
+		newStore = NewStore(wrap(inner), false)
 		go newStore.Start(time.NewTicker(10 * time.Second))
 	} else {
-		newStore = NewStore(NewTCPStatsdSink(), false)
+		newStore = NewStore(wrap(NewTCPStatsdSink()), false)
 		go newStore.Start(time.NewTicker(time.Duration(settings.FlushIntervalS) * time.Second))
 	}
 	return newStore

--- a/stats.go
+++ b/stats.go
@@ -217,21 +217,45 @@ func NewStore(sink Sink, _ bool) Store {
 	return &statStore{sink: sink}
 }
 
-// NewDefaultStore returns a Store with a TCP statsd sink, and a running flush timer.
-func NewDefaultStore() Store {
-	return NewDefaultStoreWithSink(func(sink FlushableSink) FlushableSink { return sink })
+// A StoreOption configures a Store returned by NewDefaultStore.
+type StoreOption interface {
+	apply(*storeOptions)
 }
 
-// NewDefaultStoreWithSink is like NewDefaultStore, but passes the sink it
+type storeOptions struct {
+	wrapSink func(FlushableSink) FlushableSink
+}
+
+// storeOptionFunc wraps a func so it satisfies the StoreOption interface.
+type storeOptionFunc func(*storeOptions)
+
+func (f storeOptionFunc) apply(o *storeOptions) {
+	f(o)
+}
+
+// WithSinkWrap returns a StoreOption that passes the sink NewDefaultStore
 // would otherwise have used unwrapped (chosen from Settings exactly as
-// NewDefaultStore does: a TCP statsd sink, or a logging/null sink depending
-// on UseStatsd and LoggingSinkDisabled) through wrap first.
+// NewDefaultStore always does: a TCP statsd sink, or a logging/null sink
+// depending on UseStatsd and LoggingSinkDisabled) through wrap before
+// constructing the Store.
 //
 // This lets a caller decorate that sink -- for example to filter which
 // stats actually get flushed -- without having to reimplement
 // NewDefaultStore's sink-selection logic themselves just to get at the
-// underlying sink, which NewDefaultStore itself doesn't expose.
-func NewDefaultStoreWithSink(wrap func(FlushableSink) FlushableSink) Store {
+// underlying sink, which NewDefaultStore doesn't otherwise expose.
+func WithSinkWrap(wrap func(FlushableSink) FlushableSink) StoreOption {
+	return storeOptionFunc(func(o *storeOptions) {
+		o.wrapSink = wrap
+	})
+}
+
+// NewDefaultStore returns a Store with a TCP statsd sink, and a running flush timer.
+func NewDefaultStore(opts ...StoreOption) Store {
+	so := storeOptions{wrapSink: func(sink FlushableSink) FlushableSink { return sink }}
+	for _, opt := range opts {
+		opt.apply(&so)
+	}
+
 	var newStore Store
 	settings := GetSettings()
 	if !settings.UseStatsd {
@@ -241,10 +265,10 @@ func NewDefaultStoreWithSink(wrap func(FlushableSink) FlushableSink) Store {
 		} else {
 			inner = NewLoggingSink()
 		}
-		newStore = NewStore(wrap(inner), false)
+		newStore = NewStore(so.wrapSink(inner), false)
 		go newStore.Start(time.NewTicker(10 * time.Second))
 	} else {
-		newStore = NewStore(wrap(NewTCPStatsdSink()), false)
+		newStore = NewStore(so.wrapSink(NewTCPStatsdSink()), false)
 		go newStore.Start(time.NewTicker(time.Duration(settings.FlushIntervalS) * time.Second))
 	}
 	return newStore

--- a/stats.go
+++ b/stats.go
@@ -218,19 +218,10 @@ func NewStore(sink Sink, _ bool) Store {
 }
 
 // A StoreOption configures a Store returned by NewDefaultStore.
-type StoreOption interface {
-	apply(*storeOptions)
-}
+type StoreOption func(*storeOptions)
 
 type storeOptions struct {
 	wrapSink func(FlushableSink) FlushableSink
-}
-
-// storeOptionFunc wraps a func so it satisfies the StoreOption interface.
-type storeOptionFunc func(*storeOptions)
-
-func (f storeOptionFunc) apply(o *storeOptions) {
-	f(o)
 }
 
 // WithSinkWrap returns a StoreOption that passes the sink NewDefaultStore
@@ -244,16 +235,16 @@ func (f storeOptionFunc) apply(o *storeOptions) {
 // NewDefaultStore's sink-selection logic themselves just to get at the
 // underlying sink, which NewDefaultStore doesn't otherwise expose.
 func WithSinkWrap(wrap func(FlushableSink) FlushableSink) StoreOption {
-	return storeOptionFunc(func(o *storeOptions) {
+	return func(o *storeOptions) {
 		o.wrapSink = wrap
-	})
+	}
 }
 
 // NewDefaultStore returns a Store with a TCP statsd sink, and a running flush timer.
 func NewDefaultStore(opts ...StoreOption) Store {
 	so := storeOptions{wrapSink: func(sink FlushableSink) FlushableSink { return sink }}
 	for _, opt := range opts {
-		opt.apply(&so)
+		opt(&so)
 	}
 
 	var newStore Store

--- a/stats_test.go
+++ b/stats_test.go
@@ -522,7 +522,7 @@ func BenchmarkStoreNewPerInstanceCounter(b *testing.B) {
 	})
 }
 
-func TestNewDefaultStoreWithSink_CallsWrapWithTheSinkNewDefaultStoreWouldHaveUsed(t *testing.T) {
+func TestWithSinkWrap_CallsWrapWithTheSinkNewDefaultStoreWouldHaveUsed(t *testing.T) {
 	cases := []struct {
 		name                string
 		useStatsd           string
@@ -552,10 +552,10 @@ func TestNewDefaultStoreWithSink_CallsWrapWithTheSinkNewDefaultStoreWouldHaveUse
 			t.Setenv("GOSTATS_LOGGING_SINK_DISABLED", tc.loggingSinkDisabled)
 
 			var wrapped FlushableSink
-			NewDefaultStoreWithSink(func(sink FlushableSink) FlushableSink {
+			NewDefaultStore(WithSinkWrap(func(sink FlushableSink) FlushableSink {
 				wrapped = sink
 				return sink
-			})
+			}))
 
 			if wrapped == nil {
 				t.Fatal("wrap was never called")
@@ -565,15 +565,15 @@ func TestNewDefaultStoreWithSink_CallsWrapWithTheSinkNewDefaultStoreWouldHaveUse
 	}
 }
 
-// TestNewDefaultStoreWithSink_InstallsWrappedSink proves the Store actually
-// flushes to whatever wrap returns, not to the sink NewDefaultStore would
-// otherwise have used unwrapped -- the whole point of the hook.
-func TestNewDefaultStoreWithSink_InstallsWrappedSink(t *testing.T) {
+// TestWithSinkWrap_InstallsWrappedSink proves the Store actually flushes to
+// whatever wrap returns, not to the sink NewDefaultStore would otherwise
+// have used unwrapped -- the whole point of the option.
+func TestWithSinkWrap_InstallsWrappedSink(t *testing.T) {
 	t.Setenv("USE_STATSD", "false")
 	t.Setenv("GOSTATS_LOGGING_SINK_DISABLED", "true")
 
 	replacement := mock.NewSink()
-	store := NewDefaultStoreWithSink(func(FlushableSink) FlushableSink { return replacement })
+	store := NewDefaultStore(WithSinkWrap(func(FlushableSink) FlushableSink { return replacement }))
 
 	store.NewCounter("test_counter").Inc()
 	store.Flush()
@@ -581,4 +581,16 @@ func TestNewDefaultStoreWithSink_InstallsWrappedSink(t *testing.T) {
 	if v, ok := replacement.LoadCounter("test_counter"); !ok || v != 1 {
 		t.Errorf("test_counter: got %v, %v want 1, true", v, ok)
 	}
+}
+
+// TestNewDefaultStore_NoOptions proves the zero-args call form still works
+// after NewDefaultStore became variadic.
+func TestNewDefaultStore_NoOptions(t *testing.T) {
+	t.Setenv("USE_STATSD", "false")
+	t.Setenv("GOSTATS_LOGGING_SINK_DISABLED", "true")
+
+	store := NewDefaultStore()
+
+	store.NewCounter("test_counter").Inc()
+	store.Flush() // must not panic
 }

--- a/stats_test.go
+++ b/stats_test.go
@@ -521,3 +521,64 @@ func BenchmarkStoreNewPerInstanceCounter(b *testing.B) {
 		}
 	})
 }
+
+func TestNewDefaultStoreWithSink_CallsWrapWithTheSinkNewDefaultStoreWouldHaveUsed(t *testing.T) {
+	cases := []struct {
+		name                string
+		useStatsd           string
+		loggingSinkDisabled string
+		assertType          func(t *testing.T, got FlushableSink)
+	}{
+		{"statsd", "true", "false", func(t *testing.T, got FlushableSink) {
+			if _, ok := got.(*netSink); !ok {
+				t.Errorf("wrap called with %T, want *netSink", got)
+			}
+		}},
+		{"logging", "false", "false", func(t *testing.T, got FlushableSink) {
+			if _, ok := got.(*loggingSink); !ok {
+				t.Errorf("wrap called with %T, want *loggingSink", got)
+			}
+		}},
+		{"null", "false", "true", func(t *testing.T, got FlushableSink) {
+			if _, ok := got.(nullSink); !ok {
+				t.Errorf("wrap called with %T, want nullSink", got)
+			}
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("USE_STATSD", tc.useStatsd)
+			t.Setenv("GOSTATS_LOGGING_SINK_DISABLED", tc.loggingSinkDisabled)
+
+			var wrapped FlushableSink
+			NewDefaultStoreWithSink(func(sink FlushableSink) FlushableSink {
+				wrapped = sink
+				return sink
+			})
+
+			if wrapped == nil {
+				t.Fatal("wrap was never called")
+			}
+			tc.assertType(t, wrapped)
+		})
+	}
+}
+
+// TestNewDefaultStoreWithSink_InstallsWrappedSink proves the Store actually
+// flushes to whatever wrap returns, not to the sink NewDefaultStore would
+// otherwise have used unwrapped -- the whole point of the hook.
+func TestNewDefaultStoreWithSink_InstallsWrappedSink(t *testing.T) {
+	t.Setenv("USE_STATSD", "false")
+	t.Setenv("GOSTATS_LOGGING_SINK_DISABLED", "true")
+
+	replacement := mock.NewSink()
+	store := NewDefaultStoreWithSink(func(FlushableSink) FlushableSink { return replacement })
+
+	store.NewCounter("test_counter").Inc()
+	store.Flush()
+
+	if v, ok := replacement.LoadCounter("test_counter"); !ok || v != 1 {
+		t.Errorf("test_counter: got %v, %v want 1, true", v, ok)
+	}
+}


### PR DESCRIPTION
## Summary
- `NewDefaultStore` builds its `Sink` (TCP statsd, or logging/null depending on `Settings`) entirely internally and returns only the finished `Store` -- there's no way to decorate that sink (e.g. to filter which stats are actually written) without reimplementing `NewDefaultStore`'s sink-selection logic from scratch.
- Adds a functional-options mechanism for `NewDefaultStore`, in the same spirit as the existing `SinkOption` pattern for sinks (`WithLogger`, `WithStatsdHost`, etc. in `net_sink.go`), but as a plain func type rather than an interface: `type StoreOption func(*storeOptions)`. `storeOptions` is unexported, so the interface+`apply`-method indirection `SinkOption` uses wouldn't add any real encapsulation here -- callers still can't construct a `StoreOption` themselves either way.
- `NewDefaultStore(opts ...StoreOption)` and `WithSinkWrap(wrap func(FlushableSink) FlushableSink) StoreOption`. `wrap` receives the sink `NewDefaultStore` would otherwise have used unwrapped, and its return value is what the `Store` is actually constructed with.
- `NewDefaultStore()` (no options) is unchanged -- variadic options mean every existing call site keeps compiling and behaving identically. This is purely additive.

Motivated by a downstream service (matching) that currently duplicates this exact sink-selection logic in its own repo just to wrap the sink in a stats-blocklist filter -- see the internal `statsblocklist.Sink` package for context. Opened as a draft for early feedback on the API shape before I write more tests / polish docs.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (128 passing, including new cases for `WithSinkWrap` and a zero-options `NewDefaultStore()` regression check)