### PR TITLE
internal/tags: remove deprecated rand.Seed call in test

### DIFF
--- a/internal/tags/tags_test.go
+++ b/internal/tags/tags_test.go
@@ -80,7 +80,6 @@ func TestSerializeTagsReference(t *testing.T) {
 func TestSerializeTagsNetworkSort(t *testing.T) {
 	const name = "prefix"
 
-	rand.Seed(time.Now().UnixNano())
 	seen := make(map[string]bool)
 
 	randString := func() string {


### PR DESCRIPTION
## Summary
- `rand.Seed` has been deprecated since Go 1.20 (flagged by staticcheck SA1019 in CI on the zero-alloc-tags stack): the global `math/rand` source auto-seeds since then, so this call is a no-op.

## Test plan
- `go build ./...`, `go vet ./...` clean
- `go test ./internal/tags/...` passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)